### PR TITLE
Add Geography to Indoor functionality

### DIFF
--- a/samples/AzureMapsControl.Sample/Pages/Indoor/Index.razor
+++ b/samples/AzureMapsControl.Sample/Pages/Indoor/Index.razor
@@ -25,6 +25,7 @@
 
         var options = new AzureMapsControl.Components.Indoor.IndoorManagerOptions
         {
+            Geography = Configuration["AzureMaps:Geography"],
             LevelControl = levelControl,
             StatesetId = statesetId,
             TilesetId = Configuration["Indoor:TilesetId"]

--- a/src/AzureMapsControl.Components/Indoor/IndoorManagerOptions.cs
+++ b/src/AzureMapsControl.Components/Indoor/IndoorManagerOptions.cs
@@ -40,7 +40,7 @@
     {
         public override IndoorManagerOptions Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            string statesetId = null, tilesetId = null;
+            string statesetId = null, tilesetId = null, geography = null;
             IndoorLayerTheme theme = default;
 
             if (reader.TokenType == JsonTokenType.None)
@@ -69,13 +69,19 @@
                             reader.Read();
                             tilesetId = reader.GetString();
                         }
+                        else if (reader.GetString() == "geography")
+                        {
+                            reader.Read();
+                            geography = reader.GetString();
+                        }
                     }
                 }
 
                 return new IndoorManagerOptions {
                     StatesetId = statesetId,
                     Theme = theme,
-                    TilesetId = tilesetId
+                    TilesetId = tilesetId,
+                    Geography = geography
                 };
             }
 
@@ -95,7 +101,8 @@
             {
                 writer.WriteString("theme", value.Theme.ToString());
             }
-            writer.WriteString("geography", value.Geography);
+
+            writer.WriteString("geography", value.Geography ?? "us");
             writer.WriteString("tilesetId", value.TilesetId);
             writer.WriteEndObject();
         }

--- a/src/AzureMapsControl.Components/Indoor/IndoorManagerOptions.cs
+++ b/src/AzureMapsControl.Components/Indoor/IndoorManagerOptions.cs
@@ -20,6 +20,11 @@
         public string StatesetId { get; set; }
 
         /// <summary>
+        /// The geography of the Creator resources.
+        /// </summary>
+        public string Geography { get; set; }
+
+        /// <summary>
         /// The theme for indoor layer styles.
         /// </summary>
         public IndoorLayerTheme Theme { get; set; }
@@ -89,6 +94,7 @@
             {
                 writer.WriteString("theme", value.Theme.ToString());
             }
+            writer.WriteString("geography", value.Geography.ToString());
             writer.WriteString("tilesetId", value.TilesetId);
             writer.WriteEndObject();
         }

--- a/src/AzureMapsControl.Components/Indoor/IndoorManagerOptions.cs
+++ b/src/AzureMapsControl.Components/Indoor/IndoorManagerOptions.cs
@@ -21,6 +21,7 @@
 
         /// <summary>
         /// The geography of the Creator resources.
+        /// Possible values: "us" or "eu"
         /// </summary>
         public string Geography { get; set; }
 

--- a/src/AzureMapsControl.Components/Indoor/IndoorManagerOptions.cs
+++ b/src/AzureMapsControl.Components/Indoor/IndoorManagerOptions.cs
@@ -94,7 +94,7 @@
             {
                 writer.WriteString("theme", value.Theme.ToString());
             }
-            writer.WriteString("geography", value.Geography.ToString());
+            writer.WriteString("geography", value.Geography);
             writer.WriteString("tilesetId", value.TilesetId);
             writer.WriteEndObject();
         }

--- a/src/AzureMapsControl.Components/typescript/indoor/indoor.ts
+++ b/src/AzureMapsControl.Components/typescript/indoor/indoor.ts
@@ -23,7 +23,8 @@ export class Indoor {
             levelControl,
             statesetId: options.statesetId,
             theme: options.theme,
-            tilesetId: options.tilesetId
+            tilesetId: options.tilesetId,
+            geography: options.geography
         });
 
         if (events) {
@@ -66,7 +67,8 @@ export class Indoor {
         return {
             statesetId: options.statesetId,
             theme: options.theme,
-            tilesetId: options.tilesetId
+            tilesetId: options.tilesetId,
+            geography: options.geography
         };
     }
 

--- a/src/AzureMapsControl.Components/typescript/indoor/indoor.ts
+++ b/src/AzureMapsControl.Components/typescript/indoor/indoor.ts
@@ -17,6 +17,9 @@ export class Indoor {
         if (!options.theme) {
             options.theme = 'auto';
         }
+        if (!options.geography) {
+            options.geography = 'us';
+        }
 
         const map = Core.getMap();
         const indoorManager = new indoor.indoor.IndoorManager(map, {

--- a/src/AzureMapsControl.Components/typescript/indoor/options.ts
+++ b/src/AzureMapsControl.Components/typescript/indoor/options.ts
@@ -7,4 +7,5 @@ export interface IndoorManagerOptions {
     statesetId: string;
     theme: 'auto' | 'dark' | 'light';
     tilesetId: string;
+    geography: string;
 }

--- a/src/AzureMapsControl.Components/typescript/indoor/options.ts
+++ b/src/AzureMapsControl.Components/typescript/indoor/options.ts
@@ -7,5 +7,5 @@ export interface IndoorManagerOptions {
     statesetId: string;
     theme: 'auto' | 'dark' | 'light';
     tilesetId: string;
-    geography: string;
+    geography: 'us' | 'eu';
 }

--- a/src/AzureMapsControl.Components/typings/Indoor/index.d.ts
+++ b/src/AzureMapsControl.Components/typings/Indoor/index.d.ts
@@ -288,7 +288,7 @@ declare namespace atlas {
              * The geography of the Creator resource.
              * @default "United States";
              */
-            public geography?: "United States";
+            public geography?: string;
 
             /**
              * A level picker to display as a control for the indoor manager.

--- a/src/AzureMapsControl.Components/typings/Indoor/index.d.ts
+++ b/src/AzureMapsControl.Components/typings/Indoor/index.d.ts
@@ -286,9 +286,9 @@ declare namespace atlas {
         export class IndoorManagerOptions {
             /**
              * The geography of the Creator resource.
-             * @default "United States";
+             * @default "us";
              */
-            public geography?: string;
+            public geography?: "us" | "eu";
 
             /**
              * A level picker to display as a control for the indoor manager.

--- a/tests/AzureMapsControl.Components.Tests/Indoor/IndoorManagerOptions.cs
+++ b/tests/AzureMapsControl.Components.Tests/Indoor/IndoorManagerOptions.cs
@@ -22,7 +22,8 @@
                 LevelControl = levelControl,
                 StatesetId = "statesetId",
                 Theme = IndoorLayerTheme.Auto,
-                TilesetId = "tilesetId"
+                TilesetId = "tilesetId",
+                Geography = "us"
             };
 
             var expectedJson = "{"
@@ -35,6 +36,7 @@
                 + ",\"statesetId\":\"statesetId\""
                 + ",\"theme\":\"auto\""
                 + ",\"tilesetId\":\"tilesetId\""
+                + ",\"geography\":\"us\""
                 + "}";
 
             TestAndAssertWrite(options, expectedJson);


### PR DESCRIPTION
With API 2.0 it is possible to have resources in different regions (us or eu for know). Indoor was not taking this into account yet