### PR TITLE
Remove abstract keyword from Feature class

### DIFF
--- a/samples/AzureMapsControl.Sample/Pages/Drawing/DrawingToolbar.razor
+++ b/samples/AzureMapsControl.Sample/Pages/Drawing/DrawingToolbar.razor
@@ -13,11 +13,17 @@
                                      Events = AzureMapsControl.Components.Drawing.DrawingToolbarEventActivationFlags.All()
                                  }"
           OnDrawingModeChanged="OnDrawingModeChanged"
+          OnDrawingComplete="OnDrawingComplete"
           />
 
 @code {
     public async Task OnDrawingModeChanged(AzureMapsControl.Components.Drawing.DrawingToolbarModeEventArgs eventArgs)
     {
         Console.WriteLine(eventArgs.NewMode);
+    }
+
+    public async Task OnDrawingComplete(AzureMapsControl.Components.Drawing.DrawingToolbarEventArgs eventArgs)
+    {
+        Console.WriteLine(eventArgs.Data);
     }
 }

--- a/src/AzureMapsControl.Components/Atlas/Feature.cs
+++ b/src/AzureMapsControl.Components/Atlas/Feature.cs
@@ -7,7 +7,7 @@
     using System.Text.Json.Serialization;
 
     [ExcludeFromCodeCoverage]
-    public abstract class Feature
+    public class Feature
     {
         [JsonConverter(typeof(FeatureIdConverter))]
         public string Id { get; set; }

--- a/src/AzureMapsControl.Components/Atlas/Feature.cs
+++ b/src/AzureMapsControl.Components/Atlas/Feature.cs
@@ -72,14 +72,9 @@
 
                 if (reader.TokenType == JsonTokenType.PropertyName && reader.GetString() == "id")
                 {
+                    reader.Read();
                     var converter = new FeatureIdConverter();
                     Id = converter.Read(ref reader, typeof(string), options);
-                }
-
-                if (reader.TokenType == JsonTokenType.PropertyName && reader.GetString() == "geometry")
-                {
-                    var converter = new GeometryJsonConverter();
-                    geometry = converter.Read(ref reader, typeof(Geometry), options);
                 }
 
                 if (reader.TokenType == JsonTokenType.PropertyName && reader.GetString() == "properties")
@@ -94,16 +89,7 @@
             return new Feature<Geometry>(Id, geometry, Properties);
         }
 
-        public override void Write(Utf8JsonWriter writer, Feature value, JsonSerializerOptions options)
-        {
-            writer.WriteStartObject();
-            writer.WriteString("type", value.Id);
-            writer.WritePropertyName("bbox");
-            JsonSerializer.Serialize(writer, value.BBox);
-            writer.WritePropertyName("properties");
-            JsonSerializer.Serialize(writer, value.Properties);
-            writer.WriteEndObject();
-        }
+        public override void Write(Utf8JsonWriter writer, Feature value, JsonSerializerOptions options) => throw new NotSupportedException();
 
 
     }
@@ -146,4 +132,63 @@
             writer.WriteEndObject();
         }
     }
+
+    internal class FeatureJsonConverter<TGeometry> : JsonConverter<Feature<TGeometry>> where TGeometry : Geometry
+    {
+        public FeatureJsonConverter() { }
+
+        public override Feature<TGeometry> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var originalDepth = reader.CurrentDepth;
+
+            string Id = null;
+            IDictionary<string, object> Properties = null;
+            TGeometry geometry = null;
+
+            while (reader.TokenType != JsonTokenType.EndObject || originalDepth != reader.CurrentDepth)
+            {
+                reader.Read();
+
+                if (reader.TokenType == JsonTokenType.PropertyName && reader.GetString() == "id")
+                {
+                    reader.Read();
+                    var converter = new FeatureIdConverter();
+                    Id = converter.Read(ref reader, typeof(string), options);
+                }
+
+                if (reader.TokenType == JsonTokenType.PropertyName && reader.GetString() == "geometry")
+                {
+                    var converter = new GeometryJsonConverter<TGeometry>();
+                    geometry = converter.Read(ref reader, typeof(TGeometry), options);
+                }
+
+                if (reader.TokenType == JsonTokenType.PropertyName && reader.GetString() == "properties")
+                {
+                    var converter = new FeaturePropertiesConverter();
+                    Properties = converter.Read(ref reader, typeof(IDictionary<string, object>), options);
+                }
+
+            }
+
+
+            return new Feature<TGeometry>(Id, geometry, Properties);
+        }
+
+        public override void Write(Utf8JsonWriter writer, Feature<TGeometry> value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("geometry");
+            JsonSerializer.Serialize(writer, value.Geometry);
+            writer.WriteString("id", value.Id);
+            writer.WritePropertyName("properties");
+            JsonSerializer.Serialize(writer, value.Properties);
+            writer.WritePropertyName("bbox");
+            JsonSerializer.Serialize(writer, value.BBox);
+            writer.WriteEndObject();
+        }
+
+    }
+
+
+
 }

--- a/src/AzureMapsControl.Components/Drawing/DrawingToolbarEventArgs.cs
+++ b/src/AzureMapsControl.Components/Drawing/DrawingToolbarEventArgs.cs
@@ -8,7 +8,7 @@
     [ExcludeFromCodeCoverage]
     public sealed class DrawingToolbarEventArgs : MapEventArgs
     {
-        public Feature Data { get; }
+        public Feature<Geometry> Data { get; }
 
         internal DrawingToolbarEventArgs(Map map, DrawingToolbarJsEventArgs eventArgs) : base(map, eventArgs.Type) => Data = eventArgs.Data;
     }

--- a/src/AzureMapsControl.Components/Drawing/DrawingToolbarJsEventArgs.cs
+++ b/src/AzureMapsControl.Components/Drawing/DrawingToolbarJsEventArgs.cs
@@ -9,6 +9,6 @@
     {
         public string Type { get; set; }
         public string NewMode { get; set; }
-        public Feature Data { get; set; }
+        public Feature<Geometry> Data { get; set; }
     }
 }

--- a/tests/AzureMapsControl.Components.Tests/Atlas/Feature.cs
+++ b/tests/AzureMapsControl.Components.Tests/Atlas/Feature.cs
@@ -1,0 +1,97 @@
+﻿namespace AzureMapsControl.Components.Tests.Atlas
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Text.Json;
+    using System.Threading.Tasks;
+
+    using AzureMapsControl.Components.Atlas;
+    using AzureMapsControl.Components.Tests.Json;
+
+    using Xunit;
+    public class FeaturePolygonJsonConverterTests : JsonConverterTests<Feature<Polygon>>
+    {
+        JsonSerializerOptions _jsonSerializerOptions;
+        public FeaturePolygonJsonConverterTests() : base(new FeatureJsonConverter<Polygon>())
+        {
+            _jsonSerializerOptions = new JsonSerializerOptions {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
+        }
+
+        [Fact]
+        public void Should_ReadFeature()
+        {
+            var feature = new Feature<Polygon>("b9d9f4b7-e5cc-42da-8b22-7bb36fe9fa23", new Polygon() {
+                GeometryType = "Polygon",
+                Coordinates = new[] {
+                    new [] {
+                        new Position(0, 1),
+                        new Position(2, 3)
+                    }
+                },
+                Id = "abcd-abcd-abcd-abcd-abcd"
+            }, new Dictionary<string, object> { { "_azureMapsShapeId", "efgh-efgh-efgh-efgh-efgh" } });
+            var json = JsonSerializer.Serialize(feature, _jsonSerializerOptions);
+            var result = Read(json);
+            Assert.IsType<Feature<Polygon>>(result);
+            Assert.Equal(json, JsonSerializer.Serialize(result, _jsonSerializerOptions));
+        }
+
+        [Fact]
+        public void Should_Write()
+        {
+            var geometry = new Feature<Polygon>("b9d9f4b7-e5cc-42da-8b22-7bb36fe9fa23", new Polygon() {
+                GeometryType = "Polygon",
+                Coordinates = new[] {
+                    new [] {
+                        new Position(0, 1),
+                        new Position(2, 3)
+                    }
+                },
+                Id = "abcd-abcd-abcd-abcd-abcd"
+            }, new Dictionary<string, object> { { "_azureMapsShapeId", "efgh-efgh-efgh-efgh-efgh" } });
+            TestAndAssertWrite(geometry, JsonSerializer.Serialize(geometry, _jsonSerializerOptions));
+        }
+
+    }
+
+    public class FeaturePointJsonConverterTests : JsonConverterTests<Feature<Point>>
+    {
+        JsonSerializerOptions _jsonSerializerOptions;
+        public FeaturePointJsonConverterTests() : base(new FeatureJsonConverter<Point>())
+        {
+            _jsonSerializerOptions = new JsonSerializerOptions {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
+        }
+
+        [Fact]
+        public void Should_ReadFeature()
+        {
+            var feature = new Feature<Point>("b9d9f4b7-e5cc-42da-8b22-7bb36fe9fa23", new Point() {
+                GeometryType = "Point",
+                Coordinates = new Position(0, 1),
+                Id = "abcd-abcd-abcd-abcd-abcd"
+            }, new Dictionary<string, object> { { "_azureMapsShapeId", "efgh-efgh-efgh-efgh-efgh" } });
+            var json = JsonSerializer.Serialize(feature, _jsonSerializerOptions);
+            var result = Read(json);
+            Assert.IsType<Feature<Point>>(result);
+            Assert.Equal(json, JsonSerializer.Serialize(result, _jsonSerializerOptions));
+        }
+
+        [Fact]
+        public void Should_Write()
+        {
+            var feature = new Feature<Point>("b9d9f4b7-e5cc-42da-8b22-7bb36fe9fa23", new Point() {
+                GeometryType = "Point",
+                Coordinates = new Position(0, 1),
+                Id = "abcd-abcd-abcd-abcd-abcd"
+            }, new Dictionary<string, object> { { "_azureMapsShapeId", "efgh-efgh-efgh-efgh-efgh" } });
+            TestAndAssertWrite(feature, JsonSerializer.Serialize(feature, _jsonSerializerOptions));
+        }
+
+    }
+}

--- a/tests/AzureMapsControl.Components.Tests/Atlas/Geometry.cs
+++ b/tests/AzureMapsControl.Components.Tests/Atlas/Geometry.cs
@@ -7,36 +7,6 @@
 
     using Xunit;
 
-
-    public class FeatureJsonConverterTests : JsonConverterTests<Feature>
-    {
-        public FeatureJsonConverterTests() : base(new FeatureJsonConverter()) { }
-
-        [Fact]
-        public void Should_ReadFeature()
-        {
-            var feature = new Feature<Polygon>("adsf-asfda", new Polygon() {
-                GeometryType = "Polygon",
-                Coordinates = new[] {
-                    new [] {
-                        new Position(0, 1),
-                        new Position(2, 3)
-                    }
-                },
-                Id = "d93d484e-b60e-4ef9-afec-977c09344370",
-
-
-            });
-            var json = JsonSerializer.Serialize(feature);
-            var result = Read(json);
-            Assert.IsType<Feature<Polygon>>(result);
-            Assert.Equal(json, JsonSerializer.Serialize(result));
-        }
-
-    }
-
-
-
     public class GeometryJsonConverterTests : JsonConverterTests<Geometry>
     {
         public GeometryJsonConverterTests() : base(new GeometryJsonConverter()) { }

--- a/tests/AzureMapsControl.Components.Tests/Atlas/Geometry.cs
+++ b/tests/AzureMapsControl.Components.Tests/Atlas/Geometry.cs
@@ -7,6 +7,36 @@
 
     using Xunit;
 
+
+    public class FeatureJsonConverterTests : JsonConverterTests<Feature>
+    {
+        public FeatureJsonConverterTests() : base(new FeatureJsonConverter()) { }
+
+        [Fact]
+        public void Should_ReadFeature()
+        {
+            var feature = new Feature<Polygon>("adsf-asfda", new Polygon() {
+                GeometryType = "Polygon",
+                Coordinates = new[] {
+                    new [] {
+                        new Position(0, 1),
+                        new Position(2, 3)
+                    }
+                },
+                Id = "d93d484e-b60e-4ef9-afec-977c09344370",
+
+
+            });
+            var json = JsonSerializer.Serialize(feature);
+            var result = Read(json);
+            Assert.IsType<Feature<Polygon>>(result);
+            Assert.Equal(json, JsonSerializer.Serialize(result));
+        }
+
+    }
+
+
+
     public class GeometryJsonConverterTests : JsonConverterTests<Geometry>
     {
         public GeometryJsonConverterTests() : base(new GeometryJsonConverter()) { }


### PR DESCRIPTION
Trying to bind to the  DrawingComplete eventcallback resulted in this error:

```
       Uncaught (in promise) Error: System.NotSupportedException: Deserialization of types without a parameterless constructor, a singular parameterized constructor, or a parameterized constructor annotated with 'JsonConstructorAttribute' is not supported. Type 'AzureMapsControl.Components.Atlas.Feature'. Path: $.data | LineNumber: 0 | BytePositionInLine: 34.
 ---> System.NotSupportedException: Deserialization of types without a parameterless constructor, a singular parameterized constructor, or a parameterized constructor annotated with 'JsonConstructorAttribute' is not supported. Type 'AzureMapsControl.Components.Atlas.Feature'.
   --- End of inner exception stack trace ---
   at System.Text.Json.ThrowHelper.ThrowNotSupportedException(ReadStack& state, Utf8JsonReader& reader, NotSupportedException ex)

```

Turns out it was a system.text.json error because the AzureMapsControl.Components.Atlas.Feature class is an abstract class. 
I took out the abstract keyword and tested it and it works.


- Please verify that the linting of the typescript is valid using npm run lint under src/AzureMapsControl.Components. Did this
- Please verify that the library also compiles with a release configuration using dotnet build -c Release before creating your pull request. Did this
- Please be sure that all the unit tests are passing using dotnet test. Did this
- Please verify that the rules in .editorconfig are respected. Did this
- Please update the documentation if necessary. Not needed