### PR TITLE
Easier number to Expression

### DIFF
--- a/src/AzureMapsControl.Components/Atlas/Expression.cs
+++ b/src/AzureMapsControl.Components/Atlas/Expression.cs
@@ -94,6 +94,8 @@
             /// </summary>
             public static readonly string PointCount = "point_count";
         }
+
+        public static implicit operator Expression(double? value) => new ExpressionOrNumber(value);
     }
 
     /// <summary>
@@ -123,6 +125,8 @@
         /// </summary>
         /// <param name="value">Value which will be used instead of the expression</param>
         public ExpressionOrNumber(double? value) => Value = value;
+
+        public static implicit operator ExpressionOrNumber(double? value) => new(value);
     }
 
     /// <summary>

--- a/tests/AzureMapsControl.Components.Tests/Atlas/Expression.cs
+++ b/tests/AzureMapsControl.Components.Tests/Atlas/Expression.cs
@@ -74,6 +74,13 @@
     public class ExpressionOrNumberTests
     {
         [Fact]
+        public void Number_WhenSupplied_CanBeExpressionWithoutBoilerplate()
+        {
+            var radius = Expression.Conditional(Expression.IsCluster, new ExpressionOrNumber(10), new ExpressionOrNumber(5));
+            Assert.IsType<Expression>(radius);
+        }
+
+        [Fact]
         public void Type_Is_DebugFriendly()
         {
             var attributes = typeof(ExpressionOrNumber).GetCustomAttributesData();

--- a/tests/AzureMapsControl.Components.Tests/Atlas/Expression.cs
+++ b/tests/AzureMapsControl.Components.Tests/Atlas/Expression.cs
@@ -74,9 +74,16 @@
     public class ExpressionOrNumberTests
     {
         [Fact]
+        public void Number_WhenSupplied_IsExpressionWithoutBoilerplate()
+        {
+            ExpressionOrNumber smallRadius = 10;
+            Assert.IsType<ExpressionOrNumber>(smallRadius);
+        }
+
+        [Fact]
         public void Number_WhenSupplied_CanBeExpressionWithoutBoilerplate()
         {
-            var radius = Expression.Conditional(Expression.IsCluster, new ExpressionOrNumber(10), new ExpressionOrNumber(5));
+            var radius = Expression.Conditional(Expression.IsCluster, 10, 5);
             Assert.IsType<Expression>(radius);
         }
 
@@ -123,8 +130,8 @@
         [Fact]
         public void Should_WriteNumberValue()
         {
-            var value = 1;
-            var expression = new ExpressionOrNumber(value);
+            double value = 1;
+            ExpressionOrNumber expression = value;
 
             TestAndAssertWrite(expression, value.ToString());
         }

--- a/tests/AzureMapsControl.Components.Tests/Atlas/Expression.cs
+++ b/tests/AzureMapsControl.Components.Tests/Atlas/Expression.cs
@@ -81,6 +81,21 @@
         }
 
         [Fact]
+        public void Cast_ForNull_IsNull()
+        {
+            ExpressionOrNumber expression = null;
+            Assert.Null(expression);
+        }
+
+        [Fact]
+        public void Cast_ForNullableDouble_IsExpression()
+        {
+            double? value = null;
+            ExpressionOrNumber expression = value;
+            Assert.NotNull(expression);
+        }
+
+        [Fact]
         public void Number_WhenSupplied_CanBeExpressionWithoutBoilerplate()
         {
             var radius = Expression.Conditional(Expression.IsCluster, 10, 5);


### PR DESCRIPTION
Being an enrichment  wrapper around 'double', it makes sense to let compiler convert number to Expression where it needs.

The first commit illustrates a single prop forces us to use 2 times new ExpressionOrNumber() even though intend is crystal clear and non-twofold.