### PR TITLE
Add support of GetClusterLeaves and GetClusterExpansionZoom on Datasource

### DIFF
--- a/samples/AzureMapsControl.Sample/Components/Pages/Demos/ClusterAggregates.razor
+++ b/samples/AzureMapsControl.Sample/Components/Pages/Demos/ClusterAggregates.razor
@@ -61,6 +61,7 @@
             if(cluster is not null && cluster.Properties.ContainsKey("cluster"))
             {
                 var clusterLeaves = await _datasource.GetClusterLeavesAsync(int.Parse(cluster.Id), 10, 0);
+                var clusterZoomExpansionLevel = await _datasource.GetClusterExpansionZoomAsync(int.Parse(cluster.Id));
 
                 var html = string.Join(string.Empty, 
                     new[] {

--- a/samples/AzureMapsControl.Sample/Components/Pages/Demos/ClusterAggregates.razor
+++ b/samples/AzureMapsControl.Sample/Components/Pages/Demos/ClusterAggregates.razor
@@ -60,6 +60,8 @@
 
             if(cluster is not null && cluster.Properties.ContainsKey("cluster"))
             {
+                var clusterLeaves = await _datasource.GetClusterLeavesAsync(int.Parse(cluster.Id), 10, 0);
+
                 var html = string.Join(string.Empty, 
                     new[] {
                     "<div style=\"padding:10px;\">",

--- a/src/AzureMapsControl.Components/Atlas/Feature.cs
+++ b/src/AzureMapsControl.Components/Atlas/Feature.cs
@@ -41,7 +41,10 @@
             }
             set {
                 _geometry = value;
-                _geometry.Id = Id;
+                if (_geometry != null)
+                {
+                    _geometry.Id = Id;
+                }
             }
         }
 

--- a/src/AzureMapsControl.Components/Atlas/Shape.cs
+++ b/src/AzureMapsControl.Components/Atlas/Shape.cs
@@ -34,7 +34,10 @@
             }
             set {
                 _geometry = value;
-                _geometry.Id = Id;
+                if (_geometry != null)
+                {
+                    _geometry.Id = Id;
+                }
             }
         }
 

--- a/src/AzureMapsControl.Components/Constants/Constants.cs
+++ b/src/AzureMapsControl.Components/Constants/Constants.cs
@@ -111,6 +111,7 @@
             internal static class Datasource
             {
                 internal const string GetShapes = "getShapes";
+                internal const string GetClusterLeaves = "getClusterLeaves";
             }
 
             internal static class GriddedDatasource

--- a/src/AzureMapsControl.Components/Constants/Constants.cs
+++ b/src/AzureMapsControl.Components/Constants/Constants.cs
@@ -112,6 +112,7 @@
             {
                 internal const string GetShapes = "getShapes";
                 internal const string GetClusterLeaves = "getClusterLeaves";
+                internal const string GetClusterExpansionZoom = "getClusterExpansionZoom";
             }
 
             internal static class GriddedDatasource

--- a/src/AzureMapsControl.Components/Data/DataSource.cs
+++ b/src/AzureMapsControl.Components/Data/DataSource.cs
@@ -98,7 +98,7 @@
         /// <param name="clusterId">The ID of the cluster</param>
         /// <param name="limit">The maximum number of features to return</param>
         /// <param name="offset">The number of shapes to skip. Allows you to page through the shapes in the cluster</param>
-        /// <returns></returns>
+        /// <returns>Shapes that are within the cluster</returns>
         public async ValueTask<IEnumerable<Feature<Geometry>>> GetClusterLeavesAsync(int clusterId, int limit, int offset)
         {
             Logger?.LogAzureMapsControlInfo(AzureMapLogEvent.DataSource_GetClusterLeavesAsync, "DataSource - GetClusterLeavesAsync");
@@ -111,6 +111,23 @@
             EnsureNotDisposed();
 
             return await JSRuntime.InvokeAsync<IEnumerable<Feature<Geometry>>>(Constants.JsConstants.Methods.Datasource.GetClusterLeaves.ToDatasourceNamespace(), Id, clusterId, limit, offset);
+        }
+
+        /// <summary>
+        /// Calculates a zoom level at which the cluster starts expanding or break apart.
+        /// </summary>
+        /// <param name="clusterId">ID of the cluster</param>
+        /// <returns>Zoom level at which the cluster starts expanding or break apart</returns>
+        public async ValueTask<int> GetClusterExpansionZoomAsync(int clusterId)
+        {
+            Logger?.LogAzureMapsControlInfo(AzureMapLogEvent.DataSource_GetClusterLeavesAsync, "DataSource - GetClusterExpansionZoomAsync");
+            Logger?.LogAzureMapsControlDebug(AzureMapLogEvent.DataSource_GetClusterLeavesAsync, $"Id: {Id}");
+            Logger?.LogAzureMapsControlDebug(AzureMapLogEvent.DataSource_GetClusterLeavesAsync, $"ClusterId: {clusterId}");
+
+            EnsureJsRuntimeExists();
+            EnsureNotDisposed();
+
+            return await JSRuntime.InvokeAsync<int>(Constants.JsConstants.Methods.Datasource.GetClusterExpansionZoom.ToDatasourceNamespace(), Id, clusterId);
         }
 
         internal void DispatchEvent(DataSourceEventArgs eventArgs)

--- a/src/AzureMapsControl.Components/Data/DataSource.cs
+++ b/src/AzureMapsControl.Components/Data/DataSource.cs
@@ -92,6 +92,27 @@
             return await JSRuntime.InvokeAsync<IEnumerable<Shape<Geometry>>>(Constants.JsConstants.Methods.Datasource.GetShapes.ToDatasourceNamespace(), Id);
         }
 
+        /// <summary>
+        /// Retrieves shapes that are within the cluster.
+        /// </summary>
+        /// <param name="clusterId">The ID of the cluster</param>
+        /// <param name="limit">The maximum number of features to return</param>
+        /// <param name="offset">The number of shapes to skip. Allows you to page through the shapes in the cluster</param>
+        /// <returns></returns>
+        public async ValueTask<IEnumerable<Feature<Geometry>>> GetClusterLeavesAsync(int clusterId, int limit, int offset)
+        {
+            Logger?.LogAzureMapsControlInfo(AzureMapLogEvent.DataSource_GetClusterLeavesAsync, "DataSource - GetClusterLeavesAsync");
+            Logger?.LogAzureMapsControlDebug(AzureMapLogEvent.DataSource_GetClusterLeavesAsync, $"Id: {Id}");
+            Logger?.LogAzureMapsControlDebug(AzureMapLogEvent.DataSource_GetClusterLeavesAsync, $"ClusterId: {clusterId}");
+            Logger?.LogAzureMapsControlDebug(AzureMapLogEvent.DataSource_GetClusterLeavesAsync, $"Limit: {limit}");
+            Logger?.LogAzureMapsControlDebug(AzureMapLogEvent.DataSource_GetClusterLeavesAsync, $"Offset: {offset}");
+
+            EnsureJsRuntimeExists();
+            EnsureNotDisposed();
+
+            return await JSRuntime.InvokeAsync<IEnumerable<Feature<Geometry>>>(Constants.JsConstants.Methods.Datasource.GetClusterLeaves.ToDatasourceNamespace(), Id, clusterId, limit, offset);
+        }
+
         internal void DispatchEvent(DataSourceEventArgs eventArgs)
         {
             switch (eventArgs.Type)

--- a/src/AzureMapsControl.Components/Logger/Extensions.cs
+++ b/src/AzureMapsControl.Components/Logger/Extensions.cs
@@ -69,6 +69,7 @@
         Source_GetOptionsAsync = 7005,
         Source_SetOptionsAsync = 7006,
         DataSource_GetShapesAsync = 7100,
+        DataSource_GetClusterLeavesAsync = 7101,
         GriddedDataSource_GetCellChildren = 7200,
         GriddedDataSource_GetGridCells = 7201,
         GriddedDataSource_GetPoints = 7202,

--- a/src/AzureMapsControl.Components/typescript/sources/datasource.ts
+++ b/src/AzureMapsControl.Components/typescript/sources/datasource.ts
@@ -9,4 +9,23 @@ export class Datasource {
         return shapes?.map(shape => Core.getSerializableShape(shape));
     }
 
+    public static async getClusterLeaves(datasourceId: string, clusterId: number, limit: number, offset: number) {
+        return new Promise(resolve => {
+            (Core.getMap().sources.getById(datasourceId) as azmaps.source.DataSource).getClusterLeaves(clusterId, limit, offset).then(clusterLeaves => {
+
+                const resultLeaves = clusterLeaves.map(leaf => {
+                    if (leaf instanceof azmaps.Shape) {
+                        return Core.getSerializableShape(leaf);
+                    }
+
+                    if (leaf instanceof azmaps.data.Feature) {
+                        return Core.getSerializableFeature(leaf);
+                    }
+                });
+
+                resolve(resultLeaves);
+            });
+        });
+    }
+
 }

--- a/src/AzureMapsControl.Components/typescript/sources/datasource.ts
+++ b/src/AzureMapsControl.Components/typescript/sources/datasource.ts
@@ -1,6 +1,6 @@
 import * as azmaps from 'azure-maps-control';
 import { Core } from '../core/core';
-import { Shape } from '../geometries/geometry';
+import { Shape, Feature } from '../geometries/geometry';
 
 export class Datasource {
 
@@ -9,7 +9,7 @@ export class Datasource {
         return shapes?.map(shape => Core.getSerializableShape(shape));
     }
 
-    public static async getClusterLeaves(datasourceId: string, clusterId: number, limit: number, offset: number) {
+    public static async getClusterLeaves(datasourceId: string, clusterId: number, limit: number, offset: number): Promise<(Shape | Feature)[]> {
         return new Promise(resolve => {
             (Core.getMap().sources.getById(datasourceId) as azmaps.source.DataSource).getClusterLeaves(clusterId, limit, offset).then(clusterLeaves => {
 
@@ -24,6 +24,14 @@ export class Datasource {
                 });
 
                 resolve(resultLeaves);
+            });
+        });
+    }
+
+    public static async getClusterExpansionZoom(datasourceId: string, clusterId: number): Promise<number> {
+        return new Promise(resolve => {
+            (Core.getMap().sources.getById(datasourceId) as azmaps.source.DataSource).getClusterExpansionZoom(clusterId).then(zoom => {
+                resolve(zoom);
             });
         });
     }

--- a/tests/AzureMapsControl.Components.Tests/Animations/Animation.cs
+++ b/tests/AzureMapsControl.Components.Tests/Animations/Animation.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     using AzureMapsControl.Components.Animations;
     using AzureMapsControl.Components.Runtime;
@@ -115,7 +116,7 @@
 
         [Theory]
         [MemberData(nameof(AllAnimationsTypes))]
-        public async void Should_DisposeAsync(string animationType)
+        public async Task Should_DisposeAsync(string animationType)
         {
             var id = "id";
             var animation = AnimationFactory.GetAnimation(animationType, id, _jsRuntime.Object);
@@ -128,7 +129,7 @@
 
         [Theory]
         [MemberData(nameof(AllAnimationsTypes))]
-        public async void Should_ThrowAnimationDisposedException_DisposeAsync(string animationType)
+        public async Task Should_ThrowAnimationDisposedException_DisposeAsync(string animationType)
         {
             var id = "id";
             var animation = AnimationFactory.GetAnimation(animationType, id, _jsRuntime.Object);
@@ -141,7 +142,7 @@
 
         [Theory]
         [MemberData(nameof(AllPauseAnimationsTypes))]
-        public async void Should_PauseAsync(string animationType)
+        public async Task Should_PauseAsync(string animationType)
         {
             var id = "id";
             var animation = AnimationFactory.GetAnimation(animationType, id, _jsRuntime.Object);
@@ -153,7 +154,7 @@
 
         [Theory]
         [MemberData(nameof(AllPauseAnimationsTypes))]
-        public async void Should_ThrowAnimationDisposedException_PauseAsync(string animationType)
+        public async Task Should_ThrowAnimationDisposedException_PauseAsync(string animationType)
         {
             var id = "id";
             var animation = AnimationFactory.GetAnimation(animationType, id, _jsRuntime.Object);
@@ -166,7 +167,7 @@
 
         [Theory]
         [MemberData(nameof(AllPlayAnimationsTypes))]
-        public async void Should_PlayAsync(string animationType)
+        public async Task Should_PlayAsync(string animationType)
         {
             var id = "id";
             var animation = AnimationFactory.GetAnimation(animationType, id, _jsRuntime.Object);
@@ -178,7 +179,7 @@
 
         [Theory]
         [MemberData(nameof(AllPlayAnimationsTypes))]
-        public async void Should_ThrowAnimationDisposedException_PlayAsync(string animationType)
+        public async Task Should_ThrowAnimationDisposedException_PlayAsync(string animationType)
         {
             var id = "id";
             var animation = AnimationFactory.GetAnimation(animationType, id, _jsRuntime.Object);
@@ -191,7 +192,7 @@
 
         [Theory]
         [MemberData(nameof(AllResetAnimationsTypes))]
-        public async void Should_ResetAsync(string animationType)
+        public async Task Should_ResetAsync(string animationType)
         {
             var id = "id";
             var animation = AnimationFactory.GetAnimation(animationType, id, _jsRuntime.Object);
@@ -203,7 +204,7 @@
 
         [Theory]
         [MemberData(nameof(AllResetAnimationsTypes))]
-        public async void Should_ThrowAnimationDisposedException_ResetAsync(string animationType)
+        public async Task Should_ThrowAnimationDisposedException_ResetAsync(string animationType)
         {
             var id = "id";
             var animation = AnimationFactory.GetAnimation(animationType, id, _jsRuntime.Object);
@@ -216,7 +217,7 @@
 
         [Theory]
         [MemberData(nameof(AllSeekAnimationsTypes))]
-        public async void Should_SeekAsync(string animationType)
+        public async Task Should_SeekAsync(string animationType)
         {
             var id = "id";
             var animation = AnimationFactory.GetAnimation(animationType, id, _jsRuntime.Object);
@@ -229,7 +230,7 @@
 
         [Theory]
         [MemberData(nameof(AllSeekAnimationsTypes))]
-        public async void Should_ThrowAnimationDisposedException_SeekAsync(string animationType)
+        public async Task Should_ThrowAnimationDisposedException_SeekAsync(string animationType)
         {
             var id = "id";
             var animation = AnimationFactory.GetAnimation(animationType, id, _jsRuntime.Object);
@@ -243,7 +244,7 @@
 
         [Theory]
         [MemberData(nameof(AllStopAnimationsTypes))]
-        public async void Should_StopAsync(string animationType)
+        public async Task Should_StopAsync(string animationType)
         {
             var id = "id";
             var animation = AnimationFactory.GetAnimation(animationType, id, _jsRuntime.Object);
@@ -255,7 +256,7 @@
 
         [Theory]
         [MemberData(nameof(AllStopAnimationsTypes))]
-        public async void Should_ThrowAnimationDisposedException_StopAsync(string animationType)
+        public async Task Should_ThrowAnimationDisposedException_StopAsync(string animationType)
         {
             var id = "id";
             var animation = AnimationFactory.GetAnimation(animationType, id, _jsRuntime.Object);

--- a/tests/AzureMapsControl.Components.Tests/Animations/AnimationService.cs
+++ b/tests/AzureMapsControl.Components.Tests/Animations/AnimationService.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
 
     using AzureMapsControl.Components.Animations;
     using AzureMapsControl.Components.Animations.Options;
@@ -33,7 +34,7 @@
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async void Should_Snakeline_Async(bool disposeOnComplete)
+        public async Task Should_Snakeline_Async(bool disposeOnComplete)
         {
             var line = new LineString();
             var source = new DataSource();
@@ -51,7 +52,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowArgumentNullException_Snakeline_LineCaseAsync()
+        public async Task Should_ThrowArgumentNullException_Snakeline_LineCaseAsync()
         {
             var source = new DataSource();
             var options = new SnakeLineAnimationOptions();
@@ -62,7 +63,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowArgumentNullException_Snakeline_SourceCaseAsync()
+        public async Task Should_ThrowArgumentNullException_Snakeline_SourceCaseAsync()
         {
             var line = new LineString();
             var source = new DataSource();
@@ -76,7 +77,7 @@
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async void Should_MoveAlongPath_LineStringAndPoint_DisposeOnComplete_Async(bool disposeOnComplete)
+        public async Task Should_MoveAlongPath_LineStringAndPoint_DisposeOnComplete_Async(bool disposeOnComplete)
         {
             var line = new LineString();
             var lineSource = new DataSource();
@@ -96,7 +97,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowArgumentNullException_MoveAlongPath_PathCaseAsync()
+        public async Task Should_ThrowArgumentNullException_MoveAlongPath_PathCaseAsync()
         {
             var lineSource = new DataSource();
             var pin = new Point();
@@ -109,7 +110,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowArgumentNullException_MoveAlongPath_PathSourceCaseAsync()
+        public async Task Should_ThrowArgumentNullException_MoveAlongPath_PathSourceCaseAsync()
         {
             var line = new LineString();
             var pin = new Point();
@@ -122,7 +123,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowArgumentNullException_MoveAlongPath_PinCaseAsync()
+        public async Task Should_ThrowArgumentNullException_MoveAlongPath_PinCaseAsync()
         {
             var line = new LineString();
             var lineSource = new DataSource();
@@ -135,7 +136,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowArgumentNullException_MoveAlongPath_PinSourceCaseAsync()
+        public async Task Should_ThrowArgumentNullException_MoveAlongPath_PinSourceCaseAsync()
         {
             var line = new LineString();
             var lineSource = new DataSource();
@@ -150,7 +151,7 @@
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async void Should_MoveAlongPath_LineStringAndHtmlMarker_Async(bool disposeOnComplete)
+        public async Task Should_MoveAlongPath_LineStringAndHtmlMarker_Async(bool disposeOnComplete)
         {
             var line = new LineString();
             var lineSource = new DataSource();
@@ -169,7 +170,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowArgumentNullException_MoveAlongPath_LineStringAndHtmlMarker_PathCaseAsync()
+        public async Task Should_ThrowArgumentNullException_MoveAlongPath_LineStringAndHtmlMarker_PathCaseAsync()
         {
             var lineSource = new DataSource();
             var pin = new HtmlMarker(new HtmlMarkerOptions());
@@ -181,7 +182,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowArgumentNullException_MoveAlongPath_LineStringAndHtmlMarker_PathSourceCaseAsync()
+        public async Task Should_ThrowArgumentNullException_MoveAlongPath_LineStringAndHtmlMarker_PathSourceCaseAsync()
         {
             var line = new LineString();
             var pin = new HtmlMarker(new HtmlMarkerOptions());
@@ -193,7 +194,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowArgumentNullException_MoveAlongPath_LineStringAndHtmlMarker_PinCaseAsync()
+        public async Task Should_ThrowArgumentNullException_MoveAlongPath_LineStringAndHtmlMarker_PinCaseAsync()
         {
             var line = new LineString();
             var lineSource = new DataSource();
@@ -207,7 +208,7 @@
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async void Should_MoveAlongPath_PositionsAndPoint_Async(bool disposeOnComplete)
+        public async Task Should_MoveAlongPath_PositionsAndPoint_Async(bool disposeOnComplete)
         {
             var line = new Position[] { new Position() };
             var pin = new Point();
@@ -226,7 +227,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowArgumentNullException_MoveAlongPath_PositionsAndPoint_NullLineCaseAsync()
+        public async Task Should_ThrowArgumentNullException_MoveAlongPath_PositionsAndPoint_NullLineCaseAsync()
         {
             var pin = new Point();
             var pinSource = new DataSource();
@@ -238,7 +239,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowArgumentNullException_MoveAlongPath_PositionsAndPoint_PinCaseAsync()
+        public async Task Should_ThrowArgumentNullException_MoveAlongPath_PositionsAndPoint_PinCaseAsync()
         {
             var line = new Position[] { new Position() };
             var pinSource = new DataSource();
@@ -250,7 +251,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowArgumentNullException_MoveAlongPath_PositionsAndPoint_PinSourceAsync()
+        public async Task Should_ThrowArgumentNullException_MoveAlongPath_PositionsAndPoint_PinSourceAsync()
         {
             var line = new Position[] { new Position() };
             var pin = new Point();
@@ -264,7 +265,7 @@
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async void Should_MoveAlongPath_PositionsAndHtmlMarkers_Async(bool disposeOnComplete)
+        public async Task Should_MoveAlongPath_PositionsAndHtmlMarkers_Async(bool disposeOnComplete)
         {
             var line = new Position[] { new Position() };
             var pin = new HtmlMarker(new HtmlMarkerOptions());
@@ -282,7 +283,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowArgumentNullException_MoveAlongPath_PositionsAndHtmlMarkers_NullLineCaseAsync()
+        public async Task Should_ThrowArgumentNullException_MoveAlongPath_PositionsAndHtmlMarkers_NullLineCaseAsync()
         {
             var pin = new HtmlMarker(new HtmlMarkerOptions());
             var options = new MoveAlongPathAnimationOptions();
@@ -293,7 +294,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowArgumentNullException_MoveAlongPath_PositionsAndHtmlMarkers_PinCaseAsync()
+        public async Task Should_ThrowArgumentNullException_MoveAlongPath_PositionsAndHtmlMarkers_PinCaseAsync()
         {
             var line = new Position[] { new Position() };
             var options = new MoveAlongPathAnimationOptions();
@@ -304,7 +305,7 @@
         }
 
         [Fact]
-        public async void Should_FlowingDashedLine_Async()
+        public async Task Should_FlowingDashedLine_Async()
         {
             var layer = new LineLayer();
             var options = new MovingDashLineOptions();
@@ -318,7 +319,7 @@
         }
 
         [Fact]
-        public async void Should_FlowingDashedLine_ThrowArgumentNullExceptionAsync()
+        public async Task Should_FlowingDashedLine_ThrowArgumentNullExceptionAsync()
         {
             var options = new MovingDashLineOptions();
 
@@ -330,7 +331,7 @@
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async void Should_DropMarkers_Async(bool disposeOnComplete)
+        public async Task Should_DropMarkers_Async(bool disposeOnComplete)
         {
             var map = new Map("id", htmlMarkerInvokeHelper: new HtmlMarkerInvokeHelper(null));
             _mapServiceMock.Setup(mapService => mapService.Map).Returns(map);
@@ -361,7 +362,7 @@
         }
 
         [Fact]
-        public async void Should_DropMarkers_ThrowArgumentNullExceptionAsync()
+        public async Task Should_DropMarkers_ThrowArgumentNullExceptionAsync()
         {
             var height = 1m;
             var options = new DropMarkersAnimationOptions();
@@ -373,7 +374,7 @@
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async void Should_DropMarker_Async(bool disposeOnComplete)
+        public async Task Should_DropMarker_Async(bool disposeOnComplete)
         {
             var map = new Map("id", htmlMarkerInvokeHelper: new HtmlMarkerInvokeHelper(null));
             _mapServiceMock.Setup(mapService => mapService.Map).Returns(map);
@@ -402,7 +403,7 @@
         }
 
         [Fact]
-        public async void Should_DropMarker_ThrowArgumentNullExceptionAsync()
+        public async Task Should_DropMarker_ThrowArgumentNullExceptionAsync()
         {
             var height = 1m;
             var options = new DropMarkersAnimationOptions();
@@ -412,7 +413,7 @@
         }
 
         [Fact]
-        public async void Should_GroupAnimations_Async()
+        public async Task Should_GroupAnimations_Async()
         {
             var animation1 = new SnakeLineAnimation("id", _jsRuntimeMock.Object);
             var animation2 = new DropMarkersAnimation("markerAnimation", _jsRuntimeMock.Object);
@@ -433,7 +434,7 @@
         }
 
         [Fact]
-        public async void Should_GroupAnimations_ThrowArgumentNullExceptionAsync()
+        public async Task Should_GroupAnimations_ThrowArgumentNullExceptionAsync()
         {
             var options = new GroupAnimationOptions();
 
@@ -445,7 +446,7 @@
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async void Should_DropMultiple_Async(bool disposeOnComplete)
+        public async Task Should_DropMultiple_Async(bool disposeOnComplete)
         {
             var point = new Point();
             var point2 = new Point();
@@ -466,7 +467,7 @@
         }
 
         [Fact]
-        public async void Should_DropMultiple_ThrowArgumentNullException_PointsCaseAsync()
+        public async Task Should_DropMultiple_ThrowArgumentNullException_PointsCaseAsync()
         {
             IEnumerable<Point> points = null;
             var datasource = new DataSource();
@@ -479,7 +480,7 @@
         }
 
         [Fact]
-        public async void Should_DropMultiple_ThrowArgumentNullException_SourceCaseAsync()
+        public async Task Should_DropMultiple_ThrowArgumentNullException_SourceCaseAsync()
         {
             var point = new Point();
             var point2 = new Point();
@@ -495,7 +496,7 @@
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async void Should_Drop_Async(bool disposeOnComplete)
+        public async Task Should_Drop_Async(bool disposeOnComplete)
         {
             var point = new Point();
             var datasource = new DataSource();
@@ -521,7 +522,7 @@
         }
 
         [Fact]
-        public async void Should_Drop_ThrowArgumentNullException_PointsCaseAsync()
+        public async Task Should_Drop_ThrowArgumentNullException_PointsCaseAsync()
         {
             Point points = null;
             var datasource = new DataSource();
@@ -534,7 +535,7 @@
         }
 
         [Fact]
-        public async void Should_Drop_ThrowArgumentNullException_SourceCaseAsync()
+        public async Task Should_Drop_ThrowArgumentNullException_SourceCaseAsync()
         {
             var point = new Point();
             var options = new DropAnimationOptions();
@@ -548,7 +549,7 @@
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async void Should_SetCoordinatesAsync(bool disposeOnComplete)
+        public async Task Should_SetCoordinatesAsync(bool disposeOnComplete)
         {
             var point = new Point();
             var datasource = new DataSource();
@@ -567,7 +568,7 @@
         }
 
         [Fact]
-        public async void Should_SetCoordinates_ThrowArgumentNullException_PointCaseAsync()
+        public async Task Should_SetCoordinates_ThrowArgumentNullException_PointCaseAsync()
         {
             var datasource = new DataSource();
             var options = new SetCoordinatesAnimationOptions();
@@ -579,7 +580,7 @@
         }
 
         [Fact]
-        public async void Should_SetCoordinates_ThrowArgumentNullException_SourceCaseAsync()
+        public async Task Should_SetCoordinates_ThrowArgumentNullException_SourceCaseAsync()
         {
             var point = new Point();
             var options = new SetCoordinatesAnimationOptions();
@@ -591,7 +592,7 @@
         }
 
         [Fact]
-        public async void Should_SetCoordinates_ThrowArgumentNullException_NewCoordinatesCaseAsync()
+        public async Task Should_SetCoordinates_ThrowArgumentNullException_NewCoordinatesCaseAsync()
         {
             var point = new Point();
             var datasource = new DataSource();
@@ -605,7 +606,7 @@
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async void Should_SetCoordinates_HtmlMarker_Async(bool disposeOnComplete)
+        public async Task Should_SetCoordinates_HtmlMarker_Async(bool disposeOnComplete)
         {
             var marker = new HtmlMarker(new HtmlMarkerOptions());
             var options = new SetCoordinatesAnimationOptions {
@@ -623,7 +624,7 @@
         }
 
         [Fact]
-        public async void Should_SetCoordinates_HtmlMarker_ThrowArgumentNullException_PointCaseAsync()
+        public async Task Should_SetCoordinates_HtmlMarker_ThrowArgumentNullException_PointCaseAsync()
         {
             var options = new SetCoordinatesAnimationOptions();
             var newCoordinates = new Position();
@@ -634,7 +635,7 @@
         }
 
         [Fact]
-        public async void Should_SetCoordinates_HtmlMarker_ThrowArgumentNullException_NewCoordinatesCaseAsync()
+        public async Task Should_SetCoordinates_HtmlMarker_ThrowArgumentNullException_NewCoordinatesCaseAsync()
         {
             var marker = new HtmlMarker(new HtmlMarkerOptions());
             var options = new SetCoordinatesAnimationOptions();
@@ -647,7 +648,7 @@
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async void Should_Morph_Async(bool disposeOnComplete)
+        public async Task Should_Morph_Async(bool disposeOnComplete)
         {
             var geometry = new Point();
             var dataSource = new DataSource();
@@ -667,7 +668,7 @@
         }
 
         [Fact]
-        public async void Should_Morph_ThrowArgumentNullException_GeometryCaseAsync()
+        public async Task Should_Morph_ThrowArgumentNullException_GeometryCaseAsync()
         {
             var dataSource = new DataSource();
             var newGeometry = new Polygon();
@@ -679,7 +680,7 @@
         }
 
         [Fact]
-        public async void Should_Morph_ThrowArgumentNullException_SourceCaseAsync()
+        public async Task Should_Morph_ThrowArgumentNullException_SourceCaseAsync()
         {
             var geometry = new Point();
             var newGeometry = new Polygon();
@@ -691,7 +692,7 @@
         }
 
         [Fact]
-        public async void Should_Morph_ThrowArgumentNullException_NewGeometryCaseAsync()
+        public async Task Should_Morph_ThrowArgumentNullException_NewGeometryCaseAsync()
         {
             var geometry = new Point();
             var dataSource = new DataSource();
@@ -704,7 +705,7 @@
         }
 
         [Fact]
-        public async void Should_MoveAlongRoute_Async()
+        public async Task Should_MoveAlongRoute_Async()
         {
             var routePoints = new List<RoutePoint>();
             var dataSource = new DataSource();
@@ -720,7 +721,7 @@
         }
 
         [Fact]
-        public async void Should_MoveAlongRoute_ThrowArgumentNullException_RoutePointsCaseAsync()
+        public async Task Should_MoveAlongRoute_ThrowArgumentNullException_RoutePointsCaseAsync()
         {
             var dataSource = new DataSource();
             var pin = new Point();
@@ -732,7 +733,7 @@
         }
 
         [Fact]
-        public async void Should_MoveAlongRoute_ThrowArgumentNullException_PinCaseAsync()
+        public async Task Should_MoveAlongRoute_ThrowArgumentNullException_PinCaseAsync()
         {
             var routePoints = new List<RoutePoint>();
             var dataSource = new DataSource();
@@ -744,7 +745,7 @@
         }
 
         [Fact]
-        public async void Should_MoveAlongRoute_ThrowArgumentNullException_SourceCaseAsync()
+        public async Task Should_MoveAlongRoute_ThrowArgumentNullException_SourceCaseAsync()
         {
             var routePoints = new List<RoutePoint>();
             var pin = new Point();
@@ -756,7 +757,7 @@
         }
 
         [Fact]
-        public async void Should_MoveAlongRoute_HtmlMarker_Async()
+        public async Task Should_MoveAlongRoute_HtmlMarker_Async()
         {
             var routePoints = new List<RoutePoint>();
             var pin = new HtmlMarker(new HtmlMarkerOptions());
@@ -771,7 +772,7 @@
         }
 
         [Fact]
-        public async void Should_MoveAlongRoute_HtmlMarker_ThrowArgumentNullException_RoutePointsCaseAsync()
+        public async Task Should_MoveAlongRoute_HtmlMarker_ThrowArgumentNullException_RoutePointsCaseAsync()
         {
             var pin = new HtmlMarker(new HtmlMarkerOptions());
             var options = new RoutePathAnimationOptions();
@@ -782,7 +783,7 @@
         }
 
         [Fact]
-        public async void Should_MoveAlongRoute_HtmlMarker_ThrowArgumentNullException_PinCaseAsync()
+        public async Task Should_MoveAlongRoute_HtmlMarker_ThrowArgumentNullException_PinCaseAsync()
         {
             var routePoints = new List<RoutePoint>();
             var pin = new HtmlMarker(new HtmlMarkerOptions());

--- a/tests/AzureMapsControl.Components.Tests/Animations/DropAnimation.cs
+++ b/tests/AzureMapsControl.Components.Tests/Animations/DropAnimation.cs
@@ -1,5 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Animations
 {
+    using System.Threading.Tasks;
+
     using AzureMapsControl.Components.Animations;
     using AzureMapsControl.Components.Animations.Options;
     using AzureMapsControl.Components.Runtime;
@@ -12,7 +14,7 @@
     {
         private readonly Mock<IMapJsRuntime> _jsRuntime = new Mock<IMapJsRuntime>();
         [Fact]
-        public async void Should_SetOptionsAsync()
+        public async Task Should_SetOptionsAsync()
         {
             var id = "id";
             var animation = new DropAnimation(id, _jsRuntime.Object);

--- a/tests/AzureMapsControl.Components.Tests/Animations/DropMarkersAnimation.cs
+++ b/tests/AzureMapsControl.Components.Tests/Animations/DropMarkersAnimation.cs
@@ -1,5 +1,6 @@
 ﻿namespace AzureMapsControl.Components.Tests.Animations
 {
+    using System.Threading.Tasks;
 
     using AzureMapsControl.Components.Animations;
     using AzureMapsControl.Components.Animations.Options;
@@ -13,7 +14,7 @@
     {
         private readonly Mock<IMapJsRuntime> _jsRuntime = new Mock<IMapJsRuntime>();
         [Fact]
-        public async void Should_SetOptionsAsync()
+        public async Task Should_SetOptionsAsync()
         {
             var id = "id";
             var animation = new DropMarkersAnimation(id, _jsRuntime.Object);

--- a/tests/AzureMapsControl.Components.Tests/Animations/FlowingDashedLineAnimation.cs
+++ b/tests/AzureMapsControl.Components.Tests/Animations/FlowingDashedLineAnimation.cs
@@ -1,6 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Animations
 {
     using System;
+    using System.Threading.Tasks;
 
     using AzureMapsControl.Components.Animations;
     using AzureMapsControl.Components.Animations.Options;
@@ -15,7 +16,7 @@
         private readonly Mock<IMapJsRuntime> _jsRuntime = new Mock<IMapJsRuntime>();
 
         [Fact]
-        public async void Should_ThrowException_SeekAsync()
+        public async Task Should_ThrowException_SeekAsync()
         {
             var id = "id";
             var animation = new FlowingDashedLineAnimation(id, _jsRuntime.Object);
@@ -25,7 +26,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowException_SetOptionsAsync()
+        public async Task Should_ThrowException_SetOptionsAsync()
         {
             var id = "id";
             var animation = new FlowingDashedLineAnimation(id, _jsRuntime.Object);

--- a/tests/AzureMapsControl.Components.Tests/Animations/GroupAnimation.cs
+++ b/tests/AzureMapsControl.Components.Tests/Animations/GroupAnimation.cs
@@ -1,6 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Animations
 {
     using System;
+    using System.Threading.Tasks;
 
     using AzureMapsControl.Components.Animations;
     using AzureMapsControl.Components.Animations.Options;
@@ -15,7 +16,7 @@
         private readonly Mock<IMapJsRuntime> _jsRuntime = new Mock<IMapJsRuntime>();
 
         [Fact]
-        public async void Should_ThrowException_SeekAsync()
+        public async Task Should_ThrowException_SeekAsync()
         {
             var id = "id";
             var animation = new GroupAnimation(id, _jsRuntime.Object);
@@ -25,7 +26,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowException_PauseAsync()
+        public async Task Should_ThrowException_PauseAsync()
         {
             var id = "id";
             var animation = new GroupAnimation(id, _jsRuntime.Object);
@@ -35,7 +36,7 @@
         }
 
         [Fact]
-        public async void Should_SetOptionsAsync()
+        public async Task Should_SetOptionsAsync()
         {
             var id = "id";
             var animation = new GroupAnimation(id, _jsRuntime.Object);

--- a/tests/AzureMapsControl.Components.Tests/Animations/MorphAnimation.cs
+++ b/tests/AzureMapsControl.Components.Tests/Animations/MorphAnimation.cs
@@ -1,5 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Animations
 {
+    using System.Threading.Tasks;
+
     using AzureMapsControl.Components.Animations;
     using AzureMapsControl.Components.Animations.Options;
     using AzureMapsControl.Components.Runtime;
@@ -13,7 +15,7 @@
         private readonly Mock<IMapJsRuntime> _jsRuntime = new Mock<IMapJsRuntime>();
 
         [Fact]
-        public async void Should_SetOptionsAsync()
+        public async Task Should_SetOptionsAsync()
         {
             var id = "id";
             var animation = new MorphAnimation(id, _jsRuntime.Object);

--- a/tests/AzureMapsControl.Components.Tests/Animations/MoveAlongPathAnimation.cs
+++ b/tests/AzureMapsControl.Components.Tests/Animations/MoveAlongPathAnimation.cs
@@ -1,5 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Animations
 {
+    using System.Threading.Tasks;
+
     using AzureMapsControl.Components.Animations;
     using AzureMapsControl.Components.Animations.Options;
     using AzureMapsControl.Components.Runtime;
@@ -13,7 +15,7 @@
         private readonly Mock<IMapJsRuntime> _jsRuntime = new Mock<IMapJsRuntime>();
 
         [Fact]
-        public async void Should_SetOptionsAsync()
+        public async Task Should_SetOptionsAsync()
         {
             var id = "id";
             var animation = new MoveAlongPathAnimation(id, _jsRuntime.Object);

--- a/tests/AzureMapsControl.Components.Tests/Animations/MoveAlongRouteAnimation.cs
+++ b/tests/AzureMapsControl.Components.Tests/Animations/MoveAlongRouteAnimation.cs
@@ -1,6 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Animations
 {
     using System;
+    using System.Threading.Tasks;
 
     using AzureMapsControl.Components.Animations;
     using AzureMapsControl.Components.Animations.Options;
@@ -15,7 +16,7 @@
         private readonly Mock<IMapJsRuntime> _jsRuntime = new Mock<IMapJsRuntime>();
 
         [Fact]
-        public async void Should_ThrowException_PauseAsync()
+        public async Task Should_ThrowException_PauseAsync()
         {
             var id = "id";
             var animation = new MoveAlongRouteAnimation(id, _jsRuntime.Object);
@@ -25,7 +26,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowException_PlayAsync()
+        public async Task Should_ThrowException_PlayAsync()
         {
             var id = "id";
             var animation = new MoveAlongRouteAnimation(id, _jsRuntime.Object);
@@ -35,7 +36,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowException_ResetAsync()
+        public async Task Should_ThrowException_ResetAsync()
         {
             var id = "id";
             var animation = new MoveAlongRouteAnimation(id, _jsRuntime.Object);
@@ -45,7 +46,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowException_SeekAsync()
+        public async Task Should_ThrowException_SeekAsync()
         {
             var id = "id";
             var animation = new MoveAlongRouteAnimation(id, _jsRuntime.Object);
@@ -55,7 +56,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowException_StopAsync()
+        public async Task Should_ThrowException_StopAsync()
         {
             var id = "id";
             var animation = new MoveAlongRouteAnimation(id, _jsRuntime.Object);
@@ -65,7 +66,7 @@
         }
 
         [Fact]
-        public async void Should_ThrowException_SetOptionsAsync()
+        public async Task Should_ThrowException_SetOptionsAsync()
         {
             var id = "id";
             var animation = new MoveAlongRouteAnimation(id, _jsRuntime.Object);

--- a/tests/AzureMapsControl.Components.Tests/Animations/SetCoordinatesAnimation.cs
+++ b/tests/AzureMapsControl.Components.Tests/Animations/SetCoordinatesAnimation.cs
@@ -1,5 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Animations
 {
+    using System.Threading.Tasks;
+
     using AzureMapsControl.Components.Animations;
     using AzureMapsControl.Components.Animations.Options;
     using AzureMapsControl.Components.Runtime;
@@ -13,7 +15,7 @@
         private readonly Mock<IMapJsRuntime> _jsRuntime = new Mock<IMapJsRuntime>();
 
         [Fact]
-        public async void Should_SetOptionsAsync()
+        public async Task Should_SetOptionsAsync()
         {
             var id = "id";
             var animation = new SetCoordinatesAnimation(id, _jsRuntime.Object);

--- a/tests/AzureMapsControl.Components.Tests/Animations/SnakeLineAnimation.cs
+++ b/tests/AzureMapsControl.Components.Tests/Animations/SnakeLineAnimation.cs
@@ -1,5 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Animations
 {
+    using System.Threading.Tasks;
+
     using AzureMapsControl.Components.Animations;
     using AzureMapsControl.Components.Animations.Options;
     using AzureMapsControl.Components.Runtime;
@@ -13,7 +15,7 @@
         private readonly Mock<IMapJsRuntime> _jsRuntime = new Mock<IMapJsRuntime>();
 
         [Fact]
-        public async void Should_SetOptionsAsync()
+        public async Task Should_SetOptionsAsync()
         {
             var id = "id";
             var animation = new SnakeLineAnimation(id, _jsRuntime.Object);

--- a/tests/AzureMapsControl.Components.Tests/Controls/FullScreenControl.cs
+++ b/tests/AzureMapsControl.Components.Tests/Controls/FullScreenControl.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
 
     using AzureMapsControl.Components.Controls;
     using AzureMapsControl.Components.Exceptions;
@@ -76,7 +77,7 @@
         private readonly Mock<ILogger> _loggerMock = new();
 
         [Fact]
-        public async void Should_DisposeAsync()
+        public async Task Should_DisposeAsync()
         {
             var control = new FullScreenControl {
                 JsRuntime = _jsRuntimeMock.Object,
@@ -95,7 +96,7 @@
         }
 
         [Fact]
-        public async void Should_NotDispose_NotAddedToMapCase_Async()
+        public async Task Should_NotDispose_NotAddedToMapCase_Async()
         {
             var control = new FullScreenControl {
                 Logger = _loggerMock.Object
@@ -107,7 +108,7 @@
         }
 
         [Fact]
-        public async void Should_NotDisposeTwice_Async()
+        public async Task Should_NotDisposeTwice_Async()
         {
             var control = new FullScreenControl {
                 JsRuntime = _jsRuntimeMock.Object,
@@ -128,7 +129,7 @@
         }
 
         [Fact]
-        public async void Should_SetOptionsAsync()
+        public async Task Should_SetOptionsAsync()
         {
             var control = new FullScreenControl(new FullScreenControlOptions()) {
                 JsRuntime = _jsRuntimeMock.Object,
@@ -144,7 +145,7 @@
         }
 
         [Fact]
-        public async void Should_SetOptions_NoOptionsCase_Async()
+        public async Task Should_SetOptions_NoOptionsCase_Async()
         {
             var control = new FullScreenControl {
                 JsRuntime = _jsRuntimeMock.Object,
@@ -160,7 +161,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetOptions_NotAddedToMapCase_Async()
+        public async Task Should_NotSetOptions_NotAddedToMapCase_Async()
         {
             var control = new FullScreenControl(new FullScreenControlOptions()) {
                 Logger = _loggerMock.Object
@@ -171,7 +172,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetOptions_DisposedCase_Async()
+        public async Task Should_NotSetOptions_DisposedCase_Async()
         {
             var control = new FullScreenControl(new FullScreenControlOptions()) {
                 JsRuntime = _jsRuntimeMock.Object,
@@ -186,7 +187,7 @@
         }
 
         [Fact]
-        public async void Should_GetIsFullScreenAsync()
+        public async Task Should_GetIsFullScreenAsync()
         {
             var isFullScreen = true;
             _jsRuntimeMock.Setup(runtime => runtime.InvokeAsync<bool>(It.IsAny<string>(), It.IsAny<object[]>())).ReturnsAsync(isFullScreen);
@@ -203,7 +204,7 @@
         }
 
         [Fact]
-        public async void Should_NotGetIsFullScreen_NotAddedToMapCase_Async()
+        public async Task Should_NotGetIsFullScreen_NotAddedToMapCase_Async()
         {
             var control = new FullScreenControl() {
                 Logger = _loggerMock.Object
@@ -214,7 +215,7 @@
         }
 
         [Fact]
-        public async void Should_NotGetIsFullScreen_DisposedCase_Async()
+        public async Task Should_NotGetIsFullScreen_DisposedCase_Async()
         {
             var control = new FullScreenControl() {
                 JsRuntime = _jsRuntimeMock.Object,
@@ -229,7 +230,7 @@
         }
 
         [Fact]
-        public async void Should_AddEvents_Async()
+        public async Task Should_AddEvents_Async()
         {
             var control = new FullScreenControl(eventFlags: FullScreenEventActivationFlags.All()) {
                 JsRuntime = _jsRuntimeMock.Object,
@@ -248,7 +249,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddEvents_NullCase_Async()
+        public async Task Should_NotAddEvents_NullCase_Async()
         {
             var control = new FullScreenControl() {
                 JsRuntime = _jsRuntimeMock.Object,
@@ -260,7 +261,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddEvents_EmptyCase_Async()
+        public async Task Should_NotAddEvents_EmptyCase_Async()
         {
             var control = new FullScreenControl(eventFlags: FullScreenEventActivationFlags.None()) {
                 JsRuntime = _jsRuntimeMock.Object,

--- a/tests/AzureMapsControl.Components.Tests/Controls/GeolocationControl.cs
+++ b/tests/AzureMapsControl.Components.Tests/Controls/GeolocationControl.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
 
     using AzureMapsControl.Components.Atlas;
     using AzureMapsControl.Components.Controls;
@@ -22,7 +23,7 @@
         private readonly Mock<IMapJsRuntime> _mapJsRuntimeMock = new Mock<IMapJsRuntime>();
 
         [Fact]
-        public async void Should_GetLastKnowPositionAsync()
+        public async Task Should_GetLastKnowPositionAsync()
         {
             var feature = new Feature<Point>();
             _mapJsRuntimeMock.Setup(runtime => runtime.InvokeAsync<Feature<Point>>(It.IsAny<string>(), It.IsAny<object[]>())).ReturnsAsync(feature);
@@ -39,7 +40,7 @@
         }
 
         [Fact]
-        public async void Should_NotGetLastKnowPosition_IfAlreadyDisposed_Async()
+        public async Task Should_NotGetLastKnowPosition_IfAlreadyDisposed_Async()
         {
             var control = new GeolocationControl() {
                 JsRuntime = _mapJsRuntimeMock.Object
@@ -53,7 +54,7 @@
         }
 
         [Fact]
-        public async void Should_NotGetLastKnowPosition_NotAddedToMapCase_Async()
+        public async Task Should_NotGetLastKnowPosition_NotAddedToMapCase_Async()
         {
             var control = new GeolocationControl();
 
@@ -63,7 +64,7 @@
         }
 
         [Fact]
-        public async void Should_DisposeAsync()
+        public async Task Should_DisposeAsync()
         {
             var control = new GeolocationControl() {
                 JsRuntime = _mapJsRuntimeMock.Object
@@ -81,7 +82,7 @@
         }
 
         [Fact]
-        public async void Should_NotDispose_IfAlreadyDisposed_Async()
+        public async Task Should_NotDispose_IfAlreadyDisposed_Async()
         {
             var control = new GeolocationControl() {
                 JsRuntime = _mapJsRuntimeMock.Object
@@ -94,7 +95,7 @@
         }
 
         [Fact]
-        public async void Should_NotDispose_NotAddedToMapCase_Async()
+        public async Task Should_NotDispose_NotAddedToMapCase_Async()
         {
             var control = new GeolocationControl();
             await Assert.ThrowsAnyAsync<ComponentNotAddedToMapException>(async () => await control.DisposeAsync());
@@ -103,7 +104,7 @@
         }
 
         [Fact]
-        public async void Should_SetOptions_Async()
+        public async Task Should_SetOptions_Async()
         {
             var control = new GeolocationControl() {
                 JsRuntime = _mapJsRuntimeMock.Object
@@ -118,7 +119,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetOptions_DisposedCase_Async()
+        public async Task Should_NotSetOptions_DisposedCase_Async()
         {
             var control = new GeolocationControl() {
                 JsRuntime = _mapJsRuntimeMock.Object
@@ -132,7 +133,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetOptions_NotAddedToMapCase_Async()
+        public async Task Should_NotSetOptions_NotAddedToMapCase_Async()
         {
             var control = new GeolocationControl();
 
@@ -142,7 +143,7 @@
         }
 
         [Fact]
-        public async void Should_AddEvents_Async()
+        public async Task Should_AddEvents_Async()
         {
             var control = new GeolocationControl(eventFlags: GeolocationEventActivationFlags.None().Enable(GeolocationEventType.GeolocationError)) {
                 JsRuntime = _mapJsRuntimeMock.Object
@@ -160,7 +161,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddEvents_NoEvents_Async()
+        public async Task Should_NotAddEvents_NoEvents_Async()
         {
             var control = new GeolocationControl(eventFlags: GeolocationEventActivationFlags.None()) {
                 JsRuntime = _mapJsRuntimeMock.Object
@@ -172,7 +173,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddEvents_NullCase_Async()
+        public async Task Should_NotAddEvents_NullCase_Async()
         {
             var control = new GeolocationControl() {
                 JsRuntime = _mapJsRuntimeMock.Object

--- a/tests/AzureMapsControl.Components.Tests/Controls/OverviewMapControl.cs
+++ b/tests/AzureMapsControl.Components.Tests/Controls/OverviewMapControl.cs
@@ -1,6 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Controls
 {
     using System;
+    using System.Threading.Tasks;
 
     using AzureMapsControl.Components.Controls;
     using AzureMapsControl.Components.Exceptions;
@@ -29,7 +30,7 @@
         }
 
         [Fact]
-        public async void Should_UpdateAsync()
+        public async Task Should_UpdateAsync()
         {
             var options = new OverviewMapControlOptions();
             var position = ControlPosition.BottomLeft;
@@ -47,7 +48,7 @@
         }
 
         [Fact]
-        public async void Should_NotUpdate_NotAddtoMapCase_Async()
+        public async Task Should_NotUpdate_NotAddtoMapCase_Async()
         {
             var control = new OverviewMapControl();
 
@@ -57,7 +58,7 @@
         }
 
         [Fact]
-        public async void Should_SetOptionsAsync()
+        public async Task Should_SetOptionsAsync()
         {
             var options = new OverviewMapControlOptions();
             var position = ControlPosition.BottomLeft;
@@ -75,7 +76,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetOptions_NotAddtoMapCase_Async()
+        public async Task Should_NotSetOptions_NotAddtoMapCase_Async()
         {
             var control = new OverviewMapControl();
 
@@ -85,7 +86,7 @@
         }
 
         [Fact]
-        public async void Should_UpdateAsyncWithDefaultOptionsAsync()
+        public async Task Should_UpdateAsyncWithDefaultOptionsAsync()
         {
             var control = new OverviewMapControl {
                 JsRuntime = _jsRuntimeMock.Object
@@ -101,7 +102,7 @@
         }
 
         [Fact]
-        public async void Should_SetOptionsAsyncWithDefaultOptionsAsync()
+        public async Task Should_SetOptionsAsyncWithDefaultOptionsAsync()
         {
             var control = new OverviewMapControl {
                 JsRuntime = _jsRuntimeMock.Object

--- a/tests/AzureMapsControl.Components.Tests/Data/DataSource.cs
+++ b/tests/AzureMapsControl.Components.Tests/Data/DataSource.cs
@@ -49,7 +49,7 @@
         }
 
         [Fact]
-        public async void Should_AddShapes_Async()
+        public async Task Should_AddShapes_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
 
@@ -108,7 +108,7 @@
 
 
         [Fact]
-        public async void Should_NotAddShapes_NotAddedToMapCase_Async()
+        public async Task Should_NotAddShapes_NotAddedToMapCase_Async()
         {
             var dataSource = new DataSource();
 
@@ -122,7 +122,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddShapes_DisposedCase_Async()
+        public async Task Should_NotAddShapes_DisposedCase_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             await dataSource.DisposeAsync();
@@ -139,7 +139,7 @@
 
 
         [Fact]
-        public async void Should_AddLineStringsShapes_Async()
+        public async Task Should_AddLineStringsShapes_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
 
@@ -161,7 +161,7 @@
         }
 
         [Fact]
-        public async void Should_AddFeatures_Async()
+        public async Task Should_AddFeatures_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
 
@@ -219,7 +219,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddFeatures_NotAddedToMapCase_Async()
+        public async Task Should_NotAddFeatures_NotAddedToMapCase_Async()
         {
             var dataSource = new DataSource();
 
@@ -233,7 +233,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddFeatures_DisposedCase_Async()
+        public async Task Should_NotAddFeatures_DisposedCase_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             await dataSource.DisposeAsync();
@@ -249,7 +249,7 @@
         }
 
         [Fact]
-        public async void Should_AddFeatures_ParamsVersionAsync()
+        public async Task Should_AddFeatures_ParamsVersionAsync()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
 
@@ -305,7 +305,7 @@
         }
 
         [Fact]
-        public async void Should_AddShapes_Params_Async()
+        public async Task Should_AddShapes_Params_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
 
@@ -325,7 +325,7 @@
         }
 
         [Fact]
-        public async void Should_NotCallAddCallbackIfGeometriesAreEmpty_Async()
+        public async Task Should_NotCallAddCallbackIfGeometriesAreEmpty_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
 
@@ -334,7 +334,7 @@
         }
 
         [Fact]
-        public async void Should_NotCallAddCallbackIfGeometriesAreNull_Async()
+        public async Task Should_NotCallAddCallbackIfGeometriesAreNull_Async()
         {
             IEnumerable<Shape> shapes = null;
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
@@ -344,7 +344,7 @@
         }
 
         [Fact]
-        public async void Should_ImportDataFromUrl_Async()
+        public async Task Should_ImportDataFromUrl_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
 
@@ -360,7 +360,7 @@
         }
 
         [Fact]
-        public async void Should_NotImportDataFromUrl_NotAddedToMapCase_Async()
+        public async Task Should_NotImportDataFromUrl_NotAddedToMapCase_Async()
         {
             var dataSource = new DataSource();
 
@@ -372,7 +372,7 @@
         }
 
         [Fact]
-        public async void Should_NotImportDataFromUrl_DisposedCase_Async()
+        public async Task Should_NotImportDataFromUrl_DisposedCase_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             await dataSource.DisposeAsync();
@@ -386,7 +386,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveShapes_Async()
+        public async Task Should_RemoveShapes_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Shape<Point>("point1", new Point());
@@ -408,7 +408,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveFeatures_Async()
+        public async Task Should_RemoveFeatures_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Feature<Point>("point1", new Point());
@@ -430,7 +430,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveShapes_EnumerableVersion_Async()
+        public async Task Should_RemoveShapes_EnumerableVersion_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Shape<Point>("point1", new Point());
@@ -452,7 +452,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveFeatures_EnumerableVersion_Async()
+        public async Task Should_RemoveFeatures_EnumerableVersion_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Feature<Point>("point1", new Point());
@@ -474,7 +474,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveShapes_IdsVersion_Async()
+        public async Task Should_RemoveShapes_IdsVersion_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Shape<Point>("point1", new Point());
@@ -496,7 +496,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveFeatures_IdsVersion_Async()
+        public async Task Should_RemoveFeatures_IdsVersion_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Feature<Point>("point1", new Point());
@@ -518,7 +518,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveShapesAndFeatures_IdsVersion_Async()
+        public async Task Should_RemoveShapesAndFeatures_IdsVersion_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Feature<Point>("point1", new Point());
@@ -549,7 +549,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveShapes_IdsEnumerableVersion_Async()
+        public async Task Should_RemoveShapes_IdsEnumerableVersion_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Shape<Point>("point1", new Point());
@@ -571,7 +571,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveFeatures_IdsEnumerableVersion_Async()
+        public async Task Should_RemoveFeatures_IdsEnumerableVersion_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Feature<Point>("point1", new Point());
@@ -593,7 +593,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemoveShapes_Async()
+        public async Task Should_NotRemoveShapes_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Shape<Point>("point1", new Point());
@@ -607,7 +607,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemoveFeatures_Async()
+        public async Task Should_NotRemoveFeatures_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Feature<Point>("point1", new Point());
@@ -621,7 +621,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemoveShape_NullCheck_Async()
+        public async Task Should_NotRemoveShape_NullCheck_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Shape<Point>("point1", new Point());
@@ -632,7 +632,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemoveShapesNorFeatures_NullCheck_Async()
+        public async Task Should_NotRemoveShapesNorFeatures_NullCheck_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             var shape = new Shape<Point>("point1", new Point());
@@ -651,7 +651,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemoveShapesButOnlyFeatures_Async()
+        public async Task Should_NotRemoveShapesButOnlyFeatures_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             var shape = new Shape<Point>("point1", new Point());
@@ -674,7 +674,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemoveFeaturesButOnlyShapes_Async()
+        public async Task Should_NotRemoveFeaturesButOnlyShapes_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             var shape = new Shape<Point>("point1", new Point());
@@ -697,7 +697,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveShapesAndFeatures_Async()
+        public async Task Should_RemoveShapesAndFeatures_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             var shape = new Shape<Point>("point1", new Point());
@@ -721,7 +721,7 @@
         }
 
         [Fact]
-        public async void Should_ClearDataSource_Async()
+        public async Task Should_ClearDataSource_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point2 = new Shape<Point>("point2", new Point());
@@ -741,7 +741,7 @@
         }
 
         [Fact]
-        public async void Should_ClearDataSource_NotAddedToMapCase_Async()
+        public async Task Should_ClearDataSource_NotAddedToMapCase_Async()
         {
             var dataSource = new DataSource();
 
@@ -751,7 +751,7 @@
         }
 
         [Fact]
-        public async void Should_ClearDataSource_DisposedCase_Async()
+        public async Task Should_ClearDataSource_DisposedCase_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             await dataSource.DisposeAsync();
@@ -763,7 +763,7 @@
         }
 
         [Fact]
-        public async void Should_DisposeAsync()
+        public async Task Should_DisposeAsync()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             await dataSource.DisposeAsync();
@@ -773,7 +773,7 @@
         }
 
         [Fact]
-        public async void Should_NotDispose_NotAddedToMapCase_Async()
+        public async Task Should_NotDispose_NotAddedToMapCase_Async()
         {
             var dataSource = new DataSource();
 
@@ -783,7 +783,7 @@
         }
 
         [Fact]
-        public async void Should_NotDispose_DisposedCase_Async()
+        public async Task Should_NotDispose_DisposedCase_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             await dataSource.DisposeAsync();
@@ -793,7 +793,7 @@
         }
 
         [Fact]
-        public async void Should_GetOptionsAsync()
+        public async Task Should_GetOptionsAsync()
         {
             var options = new DataSourceOptions();
             _jsRuntimeMock.Setup(runtime => runtime.InvokeAsync<DataSourceOptions>(It.IsAny<string>(), It.IsAny<object[]>())).ReturnsAsync(options);
@@ -808,7 +808,7 @@
         }
 
         [Fact]
-        public async void Should_NotGetOptions_NotAddedToMapCase_Async()
+        public async Task Should_NotGetOptions_NotAddedToMapCase_Async()
         {
             var dataSource = new DataSource() { };
 
@@ -818,7 +818,7 @@
         }
 
         [Fact]
-        public async void Should_NotGetOptions_DisposedCase_Async()
+        public async Task Should_NotGetOptions_DisposedCase_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             await dataSource.DisposeAsync();
@@ -828,7 +828,7 @@
         }
 
         [Fact]
-        public async void Should_GetShapesAsync()
+        public async Task Should_GetShapesAsync()
         {
             var shapes = Array.Empty<Shape<Geometry>>();
             _jsRuntimeMock.Setup(runtime => runtime.InvokeAsync<IEnumerable<Shape<Geometry>>>(It.IsAny<string>(), It.IsAny<object[]>())).ReturnsAsync(shapes);
@@ -842,7 +842,7 @@
         }
 
         [Fact]
-        public async void Should_NotGetShapes_NotAddedToMapCase_Async()
+        public async Task Should_NotGetShapes_NotAddedToMapCase_Async()
         {
             var dataSource = new DataSource() { };
 
@@ -852,7 +852,7 @@
         }
 
         [Fact]
-        public async void Should_NotGetShapes_DisposedCase_Async()
+        public async Task Should_NotGetShapes_DisposedCase_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             await dataSource.DisposeAsync();
@@ -927,7 +927,7 @@
         }
 
         [Fact]
-        public async void Should_AddJson_Async()
+        public async Task Should_AddJson_Async()
         {
             var shapes = Array.Empty<Shape<Geometry>>();
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
@@ -939,7 +939,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddInvalidJson_Async()
+        public async Task Should_NotAddInvalidJson_Async()
         {
             var shapes = Array.Empty<Shape<Geometry>>();
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
@@ -950,7 +950,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddJson_NotAddedToMapCase_Async()
+        public async Task Should_NotAddJson_NotAddedToMapCase_Async()
         {
             var dataSource = new DataSource() { };
 
@@ -959,7 +959,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddJson_DisposedCase_Async()
+        public async Task Should_NotAddJson_DisposedCase_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             await dataSource.DisposeAsync();
@@ -969,7 +969,7 @@
         }
 
         [Fact]
-        public async void Should_AddJson_JsonVersion_Async()
+        public async Task Should_AddJson_JsonVersion_Async()
         {
             var shapes = Array.Empty<Shape<Geometry>>();
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
@@ -983,7 +983,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddJson_NotAddedToMapCase_JsonVersion_Async()
+        public async Task Should_NotAddJson_NotAddedToMapCase_JsonVersion_Async()
         {
             var dataSource = new DataSource() { };
             var jsonDocument = JsonDocument.Parse("{}");
@@ -993,7 +993,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddJson_DisposedCase_JsonVersion_Async()
+        public async Task Should_NotAddJson_DisposedCase_JsonVersion_Async()
         {
             var dataSource = new DataSource() { JSRuntime = _jsRuntimeMock.Object };
             await dataSource.DisposeAsync();
@@ -1004,7 +1004,7 @@
         }
 
         [Fact]
-        public async void Should_SetOptionsAsync()
+        public async Task Should_SetOptionsAsync()
         {
             var datasource = new DataSource {
                 JSRuntime = _jsRuntimeMock.Object,
@@ -1022,7 +1022,7 @@
         }
 
         [Fact]
-        public async void Should_SetOptions_NoInitialValueAsync()
+        public async Task Should_SetOptions_NoInitialValueAsync()
         {
             var datasource = new DataSource {
                 JSRuntime = _jsRuntimeMock.Object
@@ -1036,7 +1036,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetOptions_NotAddedToMapCase_Async()
+        public async Task Should_NotSetOptions_NotAddedToMapCase_Async()
         {
             var datasource = new DataSource();
 
@@ -1046,7 +1046,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetOptions_DisposedCase_Async()
+        public async Task Should_NotSetOptions_DisposedCase_Async()
         {
             var datasource = new DataSource {
                 JSRuntime = _jsRuntimeMock.Object

--- a/tests/AzureMapsControl.Components.Tests/Data/DataSource.cs
+++ b/tests/AzureMapsControl.Components.Tests/Data/DataSource.cs
@@ -1103,5 +1103,48 @@
 
             _jsRuntimeMock.VerifyNoOtherCalls();
         }
+
+        [Fact]
+        public async Task Should_GetClusterExpansionZoom()
+        {
+            var datasource = new DataSource {
+                JSRuntime = _jsRuntimeMock.Object
+            };
+
+            var expected = 2;
+            _jsRuntimeMock.Setup(runtime => runtime.InvokeAsync<int>(It.IsAny<string>(), It.IsAny<object[]>())).ReturnsAsync(expected);
+
+            var clusterId = 1;
+            var result = await datasource.GetClusterExpansionZoomAsync(clusterId);
+
+            Assert.Equal(expected, result);
+
+            _jsRuntimeMock.Verify(runtime => runtime.InvokeAsync<int>(Constants.JsConstants.Methods.Datasource.GetClusterExpansionZoom.ToDatasourceNamespace(), datasource.Id, clusterId), Times.Once);
+            _jsRuntimeMock.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task Should_NotGetClusterExpansionZoom_NotAddedToMapCase()
+        {
+            var datasource = new DataSource();
+
+            await Assert.ThrowsAsync<ComponentNotAddedToMapException>(async () => await datasource.GetClusterExpansionZoomAsync(1));
+
+            _jsRuntimeMock.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task Should_NotGetClusterExpansionZoom_DisposedCase()
+        {
+            var datasource = new DataSource {
+                JSRuntime = _jsRuntimeMock.Object
+            };
+
+            await datasource.DisposeAsync();
+
+            await Assert.ThrowsAsync<ComponentDisposedException>(async () => await datasource.GetClusterExpansionZoomAsync(1));
+
+            _jsRuntimeMock.VerifyNoOtherCalls();
+        }
     }
 }

--- a/tests/AzureMapsControl.Components.Tests/Data/DataSource.cs
+++ b/tests/AzureMapsControl.Components.Tests/Data/DataSource.cs
@@ -1101,6 +1101,7 @@
 
             await Assert.ThrowsAsync<ComponentDisposedException>(async () => await datasource.GetClusterLeavesAsync(1, 2, 3));
 
+            _jsRuntimeMock.Verify(runtime => runtime.InvokeVoidAsync(Constants.JsConstants.Methods.Source.Dispose.ToSourceNamespace(), datasource.Id), Times.Once);
             _jsRuntimeMock.VerifyNoOtherCalls();
         }
 
@@ -1144,6 +1145,7 @@
 
             await Assert.ThrowsAsync<ComponentDisposedException>(async () => await datasource.GetClusterExpansionZoomAsync(1));
 
+            _jsRuntimeMock.Verify(runtime => runtime.InvokeVoidAsync(Constants.JsConstants.Methods.Source.Dispose.ToSourceNamespace(), datasource.Id), Times.Once);
             _jsRuntimeMock.VerifyNoOtherCalls();
         }
     }

--- a/tests/AzureMapsControl.Components.Tests/Data/Grid/GriddedDataSource.cs
+++ b/tests/AzureMapsControl.Components.Tests/Data/Grid/GriddedDataSource.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Text.Json;
+    using System.Threading.Tasks;
 
     using AzureMapsControl.Components.Atlas;
     using AzureMapsControl.Components.Data.Grid;
@@ -45,7 +46,7 @@
         }
 
         [Fact]
-        public async void Should_AddShapes_Async()
+        public async Task Should_AddShapes_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
 
@@ -67,7 +68,7 @@
 
 
         [Fact]
-        public async void Should_NotAddShapes_NotAddedToMapCase_Async()
+        public async Task Should_NotAddShapes_NotAddedToMapCase_Async()
         {
             var dataSource = new GriddedDataSource();
 
@@ -81,7 +82,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddShapes_DisposedCase_Async()
+        public async Task Should_NotAddShapes_DisposedCase_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             await dataSource.DisposeAsync();
@@ -97,7 +98,7 @@
         }
 
         [Fact]
-        public async void Should_AddFeatures_Async()
+        public async Task Should_AddFeatures_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
 
@@ -117,7 +118,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddFeatures_NotAddedToMapCase_Async()
+        public async Task Should_NotAddFeatures_NotAddedToMapCase_Async()
         {
             var dataSource = new GriddedDataSource();
 
@@ -131,7 +132,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddFeatures_DisposedCase_Async()
+        public async Task Should_NotAddFeatures_DisposedCase_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             await dataSource.DisposeAsync();
@@ -147,7 +148,7 @@
         }
 
         [Fact]
-        public async void Should_AddFeatures_ParamsVersionAsync()
+        public async Task Should_AddFeatures_ParamsVersionAsync()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
 
@@ -165,7 +166,7 @@
         }
 
         [Fact]
-        public async void Should_AddShapes_Params_Async()
+        public async Task Should_AddShapes_Params_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
 
@@ -185,7 +186,7 @@
         }
 
         [Fact]
-        public async void Should_NotCallAddCallbackIfGeometriesAreEmpty_Async()
+        public async Task Should_NotCallAddCallbackIfGeometriesAreEmpty_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
 
@@ -194,7 +195,7 @@
         }
 
         [Fact]
-        public async void Should_NotCallAddCallbackIfGeometriesAreNull_Async()
+        public async Task Should_NotCallAddCallbackIfGeometriesAreNull_Async()
         {
             IEnumerable<Shape<Point>> shapes = null;
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
@@ -206,7 +207,7 @@
 
 
         [Fact]
-        public async void Should_NotImportDataFromUrl_NotAddedToMapCase_Async()
+        public async Task Should_NotImportDataFromUrl_NotAddedToMapCase_Async()
         {
             var dataSource = new GriddedDataSource();
 
@@ -218,7 +219,7 @@
         }
 
         [Fact]
-        public async void Should_NotImportDataFromUrl_DisposedCase_Async()
+        public async Task Should_NotImportDataFromUrl_DisposedCase_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             await dataSource.DisposeAsync();
@@ -232,7 +233,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveShapes_Async()
+        public async Task Should_RemoveShapes_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Shape<Point>("point1", new Point());
@@ -254,7 +255,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveFeatures_Async()
+        public async Task Should_RemoveFeatures_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Feature<Point>("point1", new Point());
@@ -276,7 +277,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveShapes_EnumerableVersion_Async()
+        public async Task Should_RemoveShapes_EnumerableVersion_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Shape<Point>("point1", new Point());
@@ -298,7 +299,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveFeatures_EnumerableVersion_Async()
+        public async Task Should_RemoveFeatures_EnumerableVersion_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Feature<Point>("point1", new Point());
@@ -320,7 +321,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveShapes_IdsVersion_Async()
+        public async Task Should_RemoveShapes_IdsVersion_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Shape<Point>("point1", new Point());
@@ -342,7 +343,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveFeatures_IdsVersion_Async()
+        public async Task Should_RemoveFeatures_IdsVersion_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Feature<Point>("point1", new Point());
@@ -364,7 +365,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveShapesAndFeatures_IdsVersion_Async()
+        public async Task Should_RemoveShapesAndFeatures_IdsVersion_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Feature<Point>("point1", new Point());
@@ -395,7 +396,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveShapes_IdsEnumerableVersion_Async()
+        public async Task Should_RemoveShapes_IdsEnumerableVersion_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Shape<Point>("point1", new Point());
@@ -417,7 +418,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveFeatures_IdsEnumerableVersion_Async()
+        public async Task Should_RemoveFeatures_IdsEnumerableVersion_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Feature<Point>("point1", new Point());
@@ -439,7 +440,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemoveShapes_Async()
+        public async Task Should_NotRemoveShapes_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Shape<Point>("point1", new Point());
@@ -453,7 +454,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemoveFeatures_Async()
+        public async Task Should_NotRemoveFeatures_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Feature<Point>("point1", new Point());
@@ -467,7 +468,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemoveShape_NullCheck_Async()
+        public async Task Should_NotRemoveShape_NullCheck_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point1 = new Shape<Point>("point1", new Point());
@@ -478,7 +479,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemoveShapesNorFeatures_NullCheck_Async()
+        public async Task Should_NotRemoveShapesNorFeatures_NullCheck_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             var shape = new Shape<Point>("point1", new Point());
@@ -497,7 +498,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemoveShapesButOnlyFeatures_Async()
+        public async Task Should_NotRemoveShapesButOnlyFeatures_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             var shape = new Shape<Point>("point1", new Point());
@@ -520,7 +521,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemoveFeaturesButOnlyShapes_Async()
+        public async Task Should_NotRemoveFeaturesButOnlyShapes_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             var shape = new Shape<Point>("point1", new Point());
@@ -543,7 +544,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveShapesAndFeatures_Async()
+        public async Task Should_RemoveShapesAndFeatures_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             var shape = new Shape<Point>("point1", new Point());
@@ -567,7 +568,7 @@
         }
 
         [Fact]
-        public async void Should_ClearDataSource_Async()
+        public async Task Should_ClearDataSource_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             var point2 = new Shape<Point>("point2", new Point());
@@ -587,7 +588,7 @@
         }
 
         [Fact]
-        public async void Should_ClearDataSource_NotAddedToMapCase_Async()
+        public async Task Should_ClearDataSource_NotAddedToMapCase_Async()
         {
             var dataSource = new GriddedDataSource();
 
@@ -597,7 +598,7 @@
         }
 
         [Fact]
-        public async void Should_ClearDataSource_DisposedCase_Async()
+        public async Task Should_ClearDataSource_DisposedCase_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             await dataSource.DisposeAsync();
@@ -609,7 +610,7 @@
         }
 
         [Fact]
-        public async void Should_DisposeAsync()
+        public async Task Should_DisposeAsync()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             await dataSource.DisposeAsync();
@@ -619,7 +620,7 @@
         }
 
         [Fact]
-        public async void Should_NotDispose_NotAddedToMapCase_Async()
+        public async Task Should_NotDispose_NotAddedToMapCase_Async()
         {
             var dataSource = new GriddedDataSource();
 
@@ -629,7 +630,7 @@
         }
 
         [Fact]
-        public async void Should_NotDispose_DisposedCase_Async()
+        public async Task Should_NotDispose_DisposedCase_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             await dataSource.DisposeAsync();
@@ -639,7 +640,7 @@
         }
 
         [Fact]
-        public async void Should_GetOptionsAsync()
+        public async Task Should_GetOptionsAsync()
         {
             var options = new GriddedDataSourceOptions();
             _jsRuntimeMock.Setup(runtime => runtime.InvokeAsync<GriddedDataSourceOptions>(It.IsAny<string>(), It.IsAny<object[]>())).ReturnsAsync(options);
@@ -654,7 +655,7 @@
         }
 
         [Fact]
-        public async void Should_NotGetOptions_NotAddedToMapCase_Async()
+        public async Task Should_NotGetOptions_NotAddedToMapCase_Async()
         {
             var dataSource = new GriddedDataSource() { };
 
@@ -664,7 +665,7 @@
         }
 
         [Fact]
-        public async void Should_NotGetOptions_DisposedCase_Async()
+        public async Task Should_NotGetOptions_DisposedCase_Async()
         {
             var dataSource = new GriddedDataSource() { JSRuntime = _jsRuntimeMock.Object };
             await dataSource.DisposeAsync();
@@ -674,7 +675,7 @@
         }
 
         [Fact]
-        public async void Should_SetOptionsAsync()
+        public async Task Should_SetOptionsAsync()
         {
             var datasource = new GriddedDataSource {
                 JSRuntime = _jsRuntimeMock.Object,
@@ -692,7 +693,7 @@
         }
 
         [Fact]
-        public async void Should_SetOptions_NoInitialValueAsync()
+        public async Task Should_SetOptions_NoInitialValueAsync()
         {
             var datasource = new GriddedDataSource {
                 JSRuntime = _jsRuntimeMock.Object
@@ -706,7 +707,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetOptions_NotAddedToMapCase_Async()
+        public async Task Should_NotSetOptions_NotAddedToMapCase_Async()
         {
             var datasource = new GriddedDataSource();
 
@@ -716,7 +717,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetOptions_DisposedCase_Async()
+        public async Task Should_NotSetOptions_DisposedCase_Async()
         {
             var datasource = new GriddedDataSource {
                 JSRuntime = _jsRuntimeMock.Object
@@ -730,7 +731,7 @@
         }
 
         [Fact]
-        public async void Should_GetCellChildren_Async()
+        public async Task Should_GetCellChildren_Async()
         {
             var datasource = new GriddedDataSource {
                 JSRuntime = _jsRuntimeMock.Object
@@ -750,7 +751,7 @@
         }
 
         [Fact]
-        public async void Should_NotGetCellChildren_NotAddedToMapCase_Async()
+        public async Task Should_NotGetCellChildren_NotAddedToMapCase_Async()
         {
             var datasource = new GriddedDataSource();
 
@@ -760,7 +761,7 @@
         }
 
         [Fact]
-        public async void Should_NotGetCellChildren_DisposedCase_Async()
+        public async Task Should_NotGetCellChildren_DisposedCase_Async()
         {
             var datasource = new GriddedDataSource {
                 JSRuntime = _jsRuntimeMock.Object
@@ -774,7 +775,7 @@
         }
 
         [Fact]
-        public async void Should_GetGridCells_Async()
+        public async Task Should_GetGridCells_Async()
         {
             var datasource = new GriddedDataSource {
                 JSRuntime = _jsRuntimeMock.Object
@@ -792,7 +793,7 @@
         }
 
         [Fact]
-        public async void Should_NotGetGridCells_NotAddedToMapCase_Async()
+        public async Task Should_NotGetGridCells_NotAddedToMapCase_Async()
         {
             var datasource = new GriddedDataSource();
 
@@ -802,7 +803,7 @@
         }
 
         [Fact]
-        public async void Should_NotGetGridCells_DisposedCase_Async()
+        public async Task Should_NotGetGridCells_DisposedCase_Async()
         {
             var datasource = new GriddedDataSource {
                 JSRuntime = _jsRuntimeMock.Object
@@ -816,7 +817,7 @@
         }
 
         [Fact]
-        public async void Should_GetPoints_Async()
+        public async Task Should_GetPoints_Async()
         {
             var datasource = new GriddedDataSource {
                 JSRuntime = _jsRuntimeMock.Object
@@ -834,7 +835,7 @@
         }
 
         [Fact]
-        public async void Should_NotGetPoint_NotAddedToMapCase_Async()
+        public async Task Should_NotGetPoint_NotAddedToMapCase_Async()
         {
             var datasource = new GriddedDataSource();
 
@@ -844,7 +845,7 @@
         }
 
         [Fact]
-        public async void Should_NotGetPoints_DisposedCase_Async()
+        public async Task Should_NotGetPoints_DisposedCase_Async()
         {
             var datasource = new GriddedDataSource {
                 JSRuntime = _jsRuntimeMock.Object
@@ -858,7 +859,7 @@
         }
 
         [Fact]
-        public async void Should_SetPoints_WithFeatureCollection_Async()
+        public async Task Should_SetPoints_WithFeatureCollection_Async()
         {
             var datasource = new GriddedDataSource {
                 JSRuntime = _jsRuntimeMock.Object
@@ -872,7 +873,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetPoints_WithFeatureCollection_NotAddedToMapCase_Async()
+        public async Task Should_NotSetPoints_WithFeatureCollection_NotAddedToMapCase_Async()
         {
             var datasource = new GriddedDataSource();
 
@@ -883,7 +884,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetPoints_WithFeatureCollection_DisposedCase_Async()
+        public async Task Should_NotSetPoints_WithFeatureCollection_DisposedCase_Async()
         {
             var datasource = new GriddedDataSource {
                 JSRuntime = _jsRuntimeMock.Object
@@ -898,7 +899,7 @@
         }
 
         [Fact]
-        public async void Should_SetPoints_WithFeaturePoints_Async()
+        public async Task Should_SetPoints_WithFeaturePoints_Async()
         {
             var datasource = new GriddedDataSource {
                 JSRuntime = _jsRuntimeMock.Object
@@ -912,7 +913,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetPoints_WithFeaturePoints_NotAddedToMapCase_Async()
+        public async Task Should_NotSetPoints_WithFeaturePoints_NotAddedToMapCase_Async()
         {
             var datasource = new GriddedDataSource();
 
@@ -923,7 +924,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetPoints_WithFeaturePoints_DisposedCase_Async()
+        public async Task Should_NotSetPoints_WithFeaturePoints_DisposedCase_Async()
         {
             var datasource = new GriddedDataSource {
                 JSRuntime = _jsRuntimeMock.Object
@@ -938,7 +939,7 @@
         }
 
         [Fact]
-        public async void Should_SetPoints_WithPoints_Async()
+        public async Task Should_SetPoints_WithPoints_Async()
         {
             var datasource = new GriddedDataSource {
                 JSRuntime = _jsRuntimeMock.Object
@@ -952,7 +953,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetPoints_WithPoints_NotAddedToMapCase_Async()
+        public async Task Should_NotSetPoints_WithPoints_NotAddedToMapCase_Async()
         {
             var datasource = new GriddedDataSource();
 
@@ -963,7 +964,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetPoints_WithPoints_DisposedCase_Async()
+        public async Task Should_NotSetPoints_WithPoints_DisposedCase_Async()
         {
             var datasource = new GriddedDataSource {
                 JSRuntime = _jsRuntimeMock.Object
@@ -978,7 +979,7 @@
         }
 
         [Fact]
-        public async void Should_SetPoints_WithShapes_Async()
+        public async Task Should_SetPoints_WithShapes_Async()
         {
             var datasource = new GriddedDataSource {
                 JSRuntime = _jsRuntimeMock.Object
@@ -992,7 +993,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetPoints_WithShapes_NotAddedToMapCase_Async()
+        public async Task Should_NotSetPoints_WithShapes_NotAddedToMapCase_Async()
         {
             var datasource = new GriddedDataSource();
 
@@ -1003,7 +1004,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetPoints_WithShapes_DisposedCase_Async()
+        public async Task Should_NotSetPoints_WithShapes_DisposedCase_Async()
         {
             var datasource = new GriddedDataSource {
                 JSRuntime = _jsRuntimeMock.Object

--- a/tests/AzureMapsControl.Components.Tests/Drawing/DrawingToolbarEventInvokeHelper.cs
+++ b/tests/AzureMapsControl.Components.Tests/Drawing/DrawingToolbarEventInvokeHelper.cs
@@ -1,5 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Drawing
 {
+    using System.Threading.Tasks;
+
     using AzureMapsControl.Components.Drawing;
 
     using Xunit;
@@ -7,7 +9,7 @@
     public class DrawingToolbarEventInvokeHelperTests
     {
         [Fact]
-        public async void Should_InvokeCallback_Async()
+        public async Task Should_InvokeCallback_Async()
         {
             var drawingToolbarEventArgs = new DrawingToolbarJsEventArgs();
             var assertEqualEventArgs = false;

--- a/tests/AzureMapsControl.Components.Tests/FullScreen/FullScreenService.cs
+++ b/tests/AzureMapsControl.Components.Tests/FullScreen/FullScreenService.cs
@@ -1,5 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.FullScreen
 {
+    using System.Threading.Tasks;
+
     using AzureMapsControl.Components.FullScreen;
     using AzureMapsControl.Components.Runtime;
 
@@ -15,7 +17,7 @@
         private readonly Mock<IMapJsRuntime> _jsRuntimeMock = new();
 
         [Fact]
-        public async void Should_CheckIsSupported_Async()
+        public async Task Should_CheckIsSupported_Async()
         {
             var isSupported = true;
             _jsRuntimeMock.Setup(runtime => runtime.InvokeAsync<bool>(It.IsAny<string>(), It.IsAny<object[]>())).ReturnsAsync(isSupported);

--- a/tests/AzureMapsControl.Components.Tests/Geolocation/GeolocationService.cs
+++ b/tests/AzureMapsControl.Components.Tests/Geolocation/GeolocationService.cs
@@ -1,5 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Geolocation
 {
+    using System.Threading.Tasks;
+
     using AzureMapsControl.Components.Geolocation;
     using AzureMapsControl.Components.Runtime;
 
@@ -15,7 +17,7 @@
         private readonly Mock<IMapJsRuntime> _mapJsRuntimeMock = new Mock<IMapJsRuntime>();
 
         [Fact]
-        public async void Should_CheckIfGeolocationIsSupportedAsync()
+        public async Task Should_CheckIfGeolocationIsSupportedAsync()
         {
             var isGeolocationSupported = true;
             _mapJsRuntimeMock.Setup(runtime => runtime.InvokeAsync<bool>(It.IsAny<string>(), It.IsAny<object[]>())).ReturnsAsync(isGeolocationSupported);

--- a/tests/AzureMapsControl.Components.Tests/Indoor/IndoorManager.cs
+++ b/tests/AzureMapsControl.Components.Tests/Indoor/IndoorManager.cs
@@ -1,5 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Indoor
 {
+    using System.Threading.Tasks;
+
     using AzureMapsControl.Components.Exceptions;
     using AzureMapsControl.Components.Indoor;
     using AzureMapsControl.Components.Indoor.Style;
@@ -17,7 +19,7 @@
         private readonly Mock<ILogger> _logger = new Mock<ILogger>();
 
         [Fact]
-        public async void Should_InitializeAsync()
+        public async Task Should_InitializeAsync()
         {
             var indoorManager = new IndoorManager(_jsRuntime.Object, _logger.Object);
 
@@ -28,7 +30,7 @@
         }
 
         [Fact]
-        public async void Should_NotInitialize_DisposedCase_Async()
+        public async Task Should_NotInitialize_DisposedCase_Async()
         {
             var indoorManager = new IndoorManager(_jsRuntime.Object, _logger.Object);
 
@@ -40,7 +42,7 @@
         }
 
         [Fact]
-        public async void Should_DisposeAsync()
+        public async Task Should_DisposeAsync()
         {
             var indoorManager = new IndoorManager(_jsRuntime.Object, _logger.Object);
 
@@ -52,7 +54,7 @@
         }
 
         [Fact]
-        public async void Should_NotDisposeTwice_Async()
+        public async Task Should_NotDisposeTwice_Async()
         {
             var indoorManager = new IndoorManager(_jsRuntime.Object, _logger.Object);
 
@@ -64,7 +66,7 @@
         }
 
         [Fact]
-        public async void Should_GetCurrentFacilityAsync()
+        public async Task Should_GetCurrentFacilityAsync()
         {
             var currentFacility = new IndoorFacility {
                 FacilityId = "facilityId",
@@ -83,7 +85,7 @@
         }
 
         [Fact]
-        public async void Should_NotGetCurrentFacility_DisposedCase_Async()
+        public async Task Should_NotGetCurrentFacility_DisposedCase_Async()
         {
             var indoorManager = new IndoorManager(_jsRuntime.Object, _logger.Object);
 
@@ -95,7 +97,7 @@
         }
 
         [Fact]
-        public async void Should_GetOptionsAsync()
+        public async Task Should_GetOptionsAsync()
         {
             var options = new IndoorManagerOptions();
             _jsRuntime.Setup(runtime => runtime.InvokeAsync<IndoorManagerOptions>(It.IsAny<string>(), It.IsAny<object[]>())).ReturnsAsync(options);
@@ -109,7 +111,7 @@
         }
 
         [Fact]
-        public async void Should_NotGetOptions_DisposedCase_Async()
+        public async Task Should_NotGetOptions_DisposedCase_Async()
         {
             var indoorManager = new IndoorManager(_jsRuntime.Object, _logger.Object);
 
@@ -121,7 +123,7 @@
         }
 
         [Fact]
-        public async void Should_GetStyleDefinition_Async()
+        public async Task Should_GetStyleDefinition_Async()
         {
             var styleDefinition = new StyleDefinition();
             _jsRuntime.Setup(runtime => runtime.InvokeAsync<StyleDefinition>(It.IsAny<string>(), It.IsAny<object[]>())).ReturnsAsync(styleDefinition);
@@ -136,7 +138,7 @@
         }
 
         [Fact]
-        public async void Should_NotGetStyleDefinition_DisposedCase_Async()
+        public async Task Should_NotGetStyleDefinition_DisposedCase_Async()
         {
             var indoorManager = new IndoorManager(_jsRuntime.Object, _logger.Object);
 
@@ -148,7 +150,7 @@
         }
 
         [Fact]
-        public async void Should_SetDynamicStylingAsync()
+        public async Task Should_SetDynamicStylingAsync()
         {
             var indoorManager = new IndoorManager(_jsRuntime.Object, _logger.Object);
             await indoorManager.SetDynamicStylingAsync(true);
@@ -158,7 +160,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetDynamicStyling_DisposedCase_Async()
+        public async Task Should_NotSetDynamicStyling_DisposedCase_Async()
         {
             var indoorManager = new IndoorManager(_jsRuntime.Object, _logger.Object);
             await indoorManager.DisposeAsync();
@@ -169,7 +171,7 @@
         }
 
         [Fact]
-        public async void Should_SetFacilityAsync()
+        public async Task Should_SetFacilityAsync()
         {
             var indoorManager = new IndoorManager(_jsRuntime.Object, _logger.Object);
             await indoorManager.SetFacilityAsync("facilityId", 1);
@@ -179,7 +181,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetFacility_DisposedCase_Async()
+        public async Task Should_NotSetFacility_DisposedCase_Async()
         {
             var indoorManager = new IndoorManager(_jsRuntime.Object, _logger.Object);
             await indoorManager.DisposeAsync();
@@ -190,7 +192,7 @@
         }
 
         [Fact]
-        public async void Should_SetOptions_Async()
+        public async Task Should_SetOptions_Async()
         {
             var options = new IndoorManagerOptions();
             var indoorManager = new IndoorManager(_jsRuntime.Object, _logger.Object);
@@ -202,7 +204,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetOptions_DisposedCase_Async()
+        public async Task Should_NotSetOptions_DisposedCase_Async()
         {
             var options = new IndoorManagerOptions();
             var indoorManager = new IndoorManager(_jsRuntime.Object, _logger.Object);

--- a/tests/AzureMapsControl.Components.Tests/Indoor/IndoorService.cs
+++ b/tests/AzureMapsControl.Components.Tests/Indoor/IndoorService.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
 
     using AzureMapsControl.Components.Indoor;
     using AzureMapsControl.Components.Runtime;
@@ -19,7 +20,7 @@
         private readonly Mock<ILogger<IndoorService>> _logger = new();
 
         [Fact]
-        public async void Should_CreateIndoorManager_Async()
+        public async Task Should_CreateIndoorManager_Async()
         {
             var options = new IndoorManagerOptions();
             var service = new IndoorService(_jsRuntime.Object, _logger.Object);
@@ -30,7 +31,7 @@
         }
 
         [Fact]
-        public async void Should_CreateIndoorManagerWithEvents_Async()
+        public async Task Should_CreateIndoorManagerWithEvents_Async()
         {
             var options = new IndoorManagerOptions();
             var service = new IndoorService(_jsRuntime.Object, _logger.Object);
@@ -41,7 +42,7 @@
         }
 
         [Fact]
-        public async void Should_CreateIndoorManagerWithEvents_NullEventsCase_Async()
+        public async Task Should_CreateIndoorManagerWithEvents_NullEventsCase_Async()
         {
             var options = new IndoorManagerOptions();
             var service = new IndoorService(_jsRuntime.Object, _logger.Object);

--- a/tests/AzureMapsControl.Components.Tests/Layers/Layer.cs
+++ b/tests/AzureMapsControl.Components.Tests/Layers/Layer.cs
@@ -1,5 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Layers
 {
+    using System.Threading.Tasks;
+
     using AzureMapsControl.Components.Exceptions;
     using AzureMapsControl.Components.Layers;
     using AzureMapsControl.Components.Runtime;
@@ -22,7 +24,7 @@
         }
 
         [Fact]
-        public async void SetOptionsAsync_Should_CallInteropAsync()
+        public async Task SetOptionsAsync_Should_CallInteropAsync()
         {
             var layer = new DummyLayer {
                 _mapJsRuntime = _jsRuntimeMock.Object,
@@ -38,7 +40,7 @@
         }
 
         [Fact]
-        public async void SetOptionsAsync_Should_ThrowLayerOptionsNullExceptionAsync()
+        public async Task SetOptionsAsync_Should_ThrowLayerOptionsNullExceptionAsync()
         {
             var layer = new DummyLayer {
                 _mapJsRuntime = _jsRuntimeMock.Object
@@ -50,7 +52,7 @@
         }
 
         [Fact]
-        public async void SetOptionsAsync_Should_ThrowComponentNotAddedToMapExceptionAsync()
+        public async Task SetOptionsAsync_Should_ThrowComponentNotAddedToMapExceptionAsync()
         {
             var layer = new DummyLayer { };
             await Assert.ThrowsAnyAsync<ComponentNotAddedToMapException>(async () => await layer.SetOptionsAsync(options => options.MinZoom = 2));

--- a/tests/AzureMapsControl.Components.Tests/Layers/LayerEventInvokeHelper.cs
+++ b/tests/AzureMapsControl.Components.Tests/Layers/LayerEventInvokeHelper.cs
@@ -1,5 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Layers
 {
+    using System.Threading.Tasks;
+
     using AzureMapsControl.Components.Layers;
     using AzureMapsControl.Components.Map;
 
@@ -8,7 +10,7 @@
     public class LayerEventInvokeHelperTests
     {
         [Fact]
-        public async void Should_InvokeCallback_Async()
+        public async Task Should_InvokeCallback_Async()
         {
             var layerEventArgs = new MapJsEventArgs();
             var assertEqualEventArgs = false;

--- a/tests/AzureMapsControl.Components.Tests/Map/Map.cs
+++ b/tests/AzureMapsControl.Components.Tests/Map/Map.cs
@@ -47,7 +47,7 @@
         }
 
         [Fact]
-        public async void Should_AddControls_Async()
+        public async Task Should_AddControls_Async()
         {
             var controls = new List<Control> {
                 new CompassControl()
@@ -65,7 +65,7 @@
         }
 
         [Fact]
-        public async void Should_AddOrderedControls_Async()
+        public async Task Should_AddOrderedControls_Async()
         {
             var controls = new List<Control> {
                 new OverviewMapControl(),
@@ -84,7 +84,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddControls_NullCaseAsync()
+        public async Task Should_NotAddControls_NullCaseAsync()
         {
             const string id = "id";
             var map = new Map(id, _jsRuntimeMock.Object, _loggerMock.Object);
@@ -96,7 +96,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddControls_EmptyCaseAsync()
+        public async Task Should_NotAddControls_EmptyCaseAsync()
         {
             var controls = Array.Empty<Control>();
             const string id = "id";
@@ -109,7 +109,7 @@
         }
 
         [Fact]
-        public async void Should_AddControls_ParamsVersion_Async()
+        public async Task Should_AddControls_ParamsVersion_Async()
         {
             var control = new CompassControl(position: ControlPosition.BottomLeft);
             const string id = "id";
@@ -124,7 +124,7 @@
         }
 
         [Fact]
-        public async void Should_AddHtmlMarkers_Async()
+        public async Task Should_AddHtmlMarkers_Async()
         {
             var markers = new List<HtmlMarker> { new HtmlMarker(null), new HtmlMarker(null) };
             var popupInvokeHelper = new PopupInvokeHelper(null);
@@ -146,7 +146,7 @@
         }
 
         [Fact]
-        public async void Should_AddHtmlMarkers_WithPopup_WithAutoOpenAsync()
+        public async Task Should_AddHtmlMarkers_WithPopup_WithAutoOpenAsync()
         {
             var assertEvent = false;
             var popup = new HtmlMarkerPopup(new PopupOptions {
@@ -180,7 +180,7 @@
         }
 
         [Fact]
-        public async void Should_AddHtmlMarkers_ParamsVersion_Async()
+        public async Task Should_AddHtmlMarkers_ParamsVersion_Async()
         {
             var marker1 = new HtmlMarker(null);
             var marker2 = new HtmlMarker(null);
@@ -202,7 +202,7 @@
         }
 
         [Fact]
-        public async void Should_UpdateHtmlMarkers_Async()
+        public async Task Should_UpdateHtmlMarkers_Async()
         {
             var updates = new List<HtmlMarkerUpdate> { new HtmlMarkerUpdate(new HtmlMarker(null, null), null), new HtmlMarkerUpdate(new HtmlMarker(null, null), null) };
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object);
@@ -216,7 +216,7 @@
         }
 
         [Fact]
-        public async void Should_NotUpdateHtmlMarkers_NullCaseAsync()
+        public async Task Should_NotUpdateHtmlMarkers_NullCaseAsync()
         {
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object);
 
@@ -225,7 +225,7 @@
         }
 
         [Fact]
-        public async void Should_UpdateHtmlMarkers_ParamsVersion_Async()
+        public async Task Should_UpdateHtmlMarkers_ParamsVersion_Async()
         {
             var update1 = new HtmlMarkerUpdate(new HtmlMarker(null, null), null);
             var update2 = new HtmlMarkerUpdate(new HtmlMarker(null, null), null);
@@ -240,7 +240,7 @@
         }
 
         [Fact]
-        public async void Shoud_NotRemoveAnyHtmlMarkers_Async()
+        public async Task Shoud_NotRemoveAnyHtmlMarkers_Async()
         {
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object);
 
@@ -249,7 +249,7 @@
         }
 
         [Fact]
-        public async void Shoud_NotRemoveAnyHtmlMarkers_Null_Async()
+        public async Task Shoud_NotRemoveAnyHtmlMarkers_Null_Async()
         {
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object, htmlMarkerInvokeHelper: new HtmlMarkerInvokeHelper(eventArgs => ValueTask.CompletedTask));
             var htmlMarker = new HtmlMarker(null);
@@ -265,7 +265,7 @@
         }
 
         [Fact]
-        public async void Shoud_RemoveAnyHtmlMarkers_Async()
+        public async Task Shoud_RemoveAnyHtmlMarkers_Async()
         {
             var htmlMarker = new HtmlMarker(null);
             var htmlMarker2 = new HtmlMarker(null);
@@ -288,7 +288,7 @@
         }
 
         [Fact]
-        public async void Shoud_RemoveAnyHtmlMarkers_ParamsVersion_Async()
+        public async Task Shoud_RemoveAnyHtmlMarkers_ParamsVersion_Async()
         {
             var htmlMarker = new HtmlMarker(null);
             var htmlMarker2 = new HtmlMarker(null);
@@ -311,7 +311,7 @@
         }
 
         [Fact]
-        public async void Should_AddDrawingToolbar_Async()
+        public async Task Should_AddDrawingToolbar_Async()
         {
             var drawingToolbarOptions = new DrawingToolbarOptions();
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object, new DrawingToolbarEventInvokeHelper(eventArgs => ValueTask.CompletedTask));
@@ -327,7 +327,7 @@
         }
 
         [Fact]
-        public async void Should_UpdateDrawingToolbar_Async()
+        public async Task Should_UpdateDrawingToolbar_Async()
         {
             var drawingToolbarOptions = new DrawingToolbarOptions();
             var updateDrawingToolbarOptions = new DrawingToolbarUpdateOptions {
@@ -360,7 +360,7 @@
         }
 
         [Fact]
-        public async void Should_NotUpdateDrawingToolbar_NullCaseAsync()
+        public async Task Should_NotUpdateDrawingToolbar_NullCaseAsync()
         {
             var drawingToolbarOptions = new DrawingToolbarOptions();
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object, new DrawingToolbarEventInvokeHelper(eventArgs => ValueTask.CompletedTask));
@@ -375,7 +375,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveDrawingToolbar_Async()
+        public async Task Should_RemoveDrawingToolbar_Async()
         {
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object, new DrawingToolbarEventInvokeHelper(eventArgs => ValueTask.CompletedTask));
 
@@ -392,7 +392,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemoveDrawingToolbar_Async()
+        public async Task Should_NotRemoveDrawingToolbar_Async()
         {
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object, new DrawingToolbarEventInvokeHelper(eventArgs => ValueTask.CompletedTask));
 
@@ -403,7 +403,7 @@
         }
 
         [Fact]
-        public async void Should_AddALayer_Async()
+        public async Task Should_AddALayer_Async()
         {
             var layer = new BubbleLayer();
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object, layerEventInvokeHelper: new LayerEventInvokeHelper(eventArgs => ValueTask.CompletedTask));
@@ -423,7 +423,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddALayer_NullCaseAsync()
+        public async Task Should_NotAddALayer_NullCaseAsync()
         {
             BubbleLayer layer = null;
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object, layerEventInvokeHelper: new LayerEventInvokeHelper(eventArgs => ValueTask.CompletedTask));
@@ -435,7 +435,7 @@
         }
 
         [Fact]
-        public async void Should_AddALayerWithBefore_Async()
+        public async Task Should_AddALayerWithBefore_Async()
         {
             var layer = new BubbleLayer();
             const string before = "before";
@@ -456,7 +456,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddLayerWithSameId_Async()
+        public async Task Should_NotAddLayerWithSameId_Async()
         {
             var layer = new BubbleLayer();
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object, layerEventInvokeHelper: new LayerEventInvokeHelper(eventArgs => ValueTask.CompletedTask));
@@ -476,7 +476,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveOneLayer_Async()
+        public async Task Should_RemoveOneLayer_Async()
         {
             var layer1 = new BubbleLayer();
             var layer2 = new BubbleLayer();
@@ -497,7 +497,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveMultipleLayers_Async()
+        public async Task Should_RemoveMultipleLayers_Async()
         {
             var layer1 = new BubbleLayer();
             var layer2 = new BubbleLayer();
@@ -518,7 +518,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveMultipleLayers_ParamsVersion_Async()
+        public async Task Should_RemoveMultipleLayers_ParamsVersion_Async()
         {
             var layer1 = new BubbleLayer();
             var layer2 = new BubbleLayer();
@@ -539,7 +539,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveMultipleLayers_ViaId_Async()
+        public async Task Should_RemoveMultipleLayers_ViaId_Async()
         {
             var layer1 = new BubbleLayer();
             var layer2 = new BubbleLayer();
@@ -560,7 +560,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveMultipleLayers_ViaId_ParamsVersion_Async()
+        public async Task Should_RemoveMultipleLayers_ViaId_ParamsVersion_Async()
         {
             var layer1 = new BubbleLayer();
             var layer2 = new BubbleLayer();
@@ -581,7 +581,7 @@
         }
 
         [Fact]
-        public async void Should_AddDataSource_Async()
+        public async Task Should_AddDataSource_Async()
         {
             var dataSource = new DataSource {
                 EventActivationFlags = DataSourceEventActivationFlags.None().Enable(DataSourceEventType.DataAdded)
@@ -605,7 +605,7 @@
         }
 
         [Fact]
-        public async void Should_AddVectorTileSourceAsync()
+        public async Task Should_AddVectorTileSourceAsync()
         {
             var source = new VectorTileSource();
 
@@ -623,7 +623,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddDataSource_Async()
+        public async Task Should_NotAddDataSource_Async()
         {
             var dataSource = new DataSource();
 
@@ -639,7 +639,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddDataSource_NullCaseAsync()
+        public async Task Should_NotAddDataSource_NullCaseAsync()
         {
             DataSource dataSource = null;
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object);
@@ -648,7 +648,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveDataSource_Async()
+        public async Task Should_RemoveDataSource_Async()
         {
             var dataSource = new DataSource();
             var dataSource2 = new DataSource();
@@ -676,7 +676,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemoveDataSource_Async()
+        public async Task Should_NotRemoveDataSource_Async()
         {
             var dataSource = new DataSource();
             var dataSource2 = new DataSource();
@@ -697,7 +697,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveDataSource_ViaId_Async()
+        public async Task Should_RemoveDataSource_ViaId_Async()
         {
             var dataSource = new DataSource();
             var dataSource2 = new DataSource();
@@ -725,7 +725,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemoveDataSource_ViaId_Async()
+        public async Task Should_NotRemoveDataSource_ViaId_Async()
         {
             var dataSource = new DataSource();
             var dataSource2 = new DataSource();
@@ -746,7 +746,7 @@
         }
 
         [Fact]
-        public async void Should_ClearMap_Async()
+        public async Task Should_ClearMap_Async()
         {
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object, new DrawingToolbarEventInvokeHelper(eventArgs => ValueTask.CompletedTask),
                 new HtmlMarkerInvokeHelper(eventArgs => ValueTask.CompletedTask),
@@ -774,7 +774,7 @@
         }
 
         [Fact]
-        public async void Should_ClearLayers_Async()
+        public async Task Should_ClearLayers_Async()
         {
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object, layerEventInvokeHelper: new LayerEventInvokeHelper(eventArgs => ValueTask.CompletedTask));
             await map.AddLayerAsync(new BubbleLayer());
@@ -788,7 +788,7 @@
         }
 
         [Fact]
-        public async void Should_ClearDataSources_Async()
+        public async Task Should_ClearDataSources_Async()
         {
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object, dataSourceEventInvokeHelper: new DataSourceEventInvokeHelper(_ => ValueTask.CompletedTask));
 
@@ -801,7 +801,7 @@
         }
 
         [Fact]
-        public async void Should_ClearHtmlMarkers_Async()
+        public async Task Should_ClearHtmlMarkers_Async()
         {
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object, htmlMarkerInvokeHelper: new HtmlMarkerInvokeHelper(eventArgs => ValueTask.CompletedTask));
 
@@ -819,7 +819,7 @@
         }
 
         [Fact]
-        public async void Should_AddPopup_Async()
+        public async Task Should_AddPopup_Async()
         {
             var popup = new Popup(new PopupOptions());
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object, popupInvokeHelper: new PopupInvokeHelper(eventArgs => ValueTask.CompletedTask));
@@ -837,7 +837,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddPopup_NullCaseAsync()
+        public async Task Should_NotAddPopup_NullCaseAsync()
         {
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object, popupInvokeHelper: new PopupInvokeHelper(eventArgs => ValueTask.CompletedTask));
             await Assert.ThrowsAnyAsync<ArgumentNullException>(async () => await map.AddPopupAsync(null));
@@ -845,7 +845,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddTwiceTheSamePopup_Async()
+        public async Task Should_NotAddTwiceTheSamePopup_Async()
         {
             var popup = new Popup(new PopupOptions());
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object, popupInvokeHelper: new PopupInvokeHelper(eventArgs => ValueTask.CompletedTask));
@@ -862,7 +862,7 @@
         }
 
         [Fact]
-        public async void Should_AddPopupWithTemplate_Async()
+        public async Task Should_AddPopupWithTemplate_Async()
         {
             var popup = new Popup(new PopupOptions());
             var popupTemplate = new PopupTemplate();
@@ -884,7 +884,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddPopupWithTemplate_NullCaseAsync()
+        public async Task Should_NotAddPopupWithTemplate_NullCaseAsync()
         {
             var popupTemplate = new PopupTemplate();
             var properties = new Dictionary<string, object>();
@@ -894,7 +894,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddPopupWithTemplate_NullTemplateCaseAsync()
+        public async Task Should_NotAddPopupWithTemplate_NullTemplateCaseAsync()
         {
             var popup = new Popup(new PopupOptions());
             var properties = new Dictionary<string, object>();
@@ -904,7 +904,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddPopupWithTemplate_NullPropertiesCaseAsync()
+        public async Task Should_NotAddPopupWithTemplate_NullPropertiesCaseAsync()
         {
             var popup = new Popup(new PopupOptions());
             var popupTemplate = new PopupTemplate();
@@ -914,7 +914,7 @@
         }
 
         [Fact]
-        public async void Should_NotAddTwiceTheSamePopupWithTemplate_Async()
+        public async Task Should_NotAddTwiceTheSamePopupWithTemplate_Async()
         {
             var popup = new Popup(new PopupOptions());
             var popupTemplate = new PopupTemplate();
@@ -935,7 +935,7 @@
         }
 
         [Fact]
-        public async void Should_RemovePopup_Async()
+        public async Task Should_RemovePopup_Async()
         {
             var popup = new Popup(new PopupOptions()) {
                 JSRuntime = _jsRuntimeMock.Object
@@ -951,7 +951,7 @@
         }
 
         [Fact]
-        public async void Should_RemovePopup_IdVersion_Async()
+        public async Task Should_RemovePopup_IdVersion_Async()
         {
             var popup = new Popup(new PopupOptions()) {
                 JSRuntime = _jsRuntimeMock.Object
@@ -967,7 +967,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemovePopup_Async()
+        public async Task Should_NotRemovePopup_Async()
         {
             var popup = new Popup(new PopupOptions());
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object, popupInvokeHelper: new PopupInvokeHelper(eventArgs => ValueTask.CompletedTask));
@@ -979,7 +979,7 @@
         }
 
         [Fact]
-        public async void Should_ClearPopups_Async()
+        public async Task Should_ClearPopups_Async()
         {
             var popup = new Popup(new PopupOptions());
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object, popupInvokeHelper: new PopupInvokeHelper(eventArgs => ValueTask.CompletedTask));
@@ -993,7 +993,7 @@
         }
 
         [Fact]
-        public async void Should_UpdateCameraOptions_Async()
+        public async Task Should_UpdateCameraOptions_Async()
         {
             var center = new Position(10, 10);
             var initialCameraOptions = new CameraOptions {
@@ -1011,7 +1011,7 @@
         }
 
         [Fact]
-        public async void Should_UpdateCameraOptions_WithCenter_Async()
+        public async Task Should_UpdateCameraOptions_WithCenter_Async()
         {
             var center = new Position(10, 10);
             var initialCameraOptions = new CameraOptions {
@@ -1030,7 +1030,7 @@
         }
 
         [Fact]
-        public async void Should_UpdateCameraOptions_WithBounds_Async()
+        public async Task Should_UpdateCameraOptions_WithBounds_Async()
         {
             var bounds = new BoundingBox(-10, 10, 10, -10);
             var initialCameraOptions = new CameraOptions {
@@ -1055,7 +1055,7 @@
         }
 
         [Fact]
-        public async void Should_UpdateCameraOptions_NoCameraOptionsDefined_Async()
+        public async Task Should_UpdateCameraOptions_NoCameraOptionsDefined_Async()
         {
             var center = new Position(10, 10);
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object);
@@ -1068,7 +1068,7 @@
         }
 
         [Fact]
-        public async void Should_UpdateStyleOptions_Async()
+        public async Task Should_UpdateStyleOptions_Async()
         {
             var language = "fr";
             var initialStyleOptions = new StyleOptions {
@@ -1086,7 +1086,7 @@
         }
 
         [Fact]
-        public async void Should_UpdateStyleOptions_NoStyleOptionsDefined_Async()
+        public async Task Should_UpdateStyleOptions_NoStyleOptionsDefined_Async()
         {
             var language = "fr";
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object);
@@ -1099,7 +1099,7 @@
         }
 
         [Fact]
-        public async void Should_UpdateUserInteraction_Async()
+        public async Task Should_UpdateUserInteraction_Async()
         {
             var initialUserInteractionOptions = new UserInteractionOptions {
                 BoxZoomInteraction = true
@@ -1117,7 +1117,7 @@
         }
 
         [Fact]
-        public async void Should_UpdateUserInteraction_NoUserInteractionDefined_Async()
+        public async Task Should_UpdateUserInteraction_NoUserInteractionDefined_Async()
         {
             var dblClickZoomInteraction = true;
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object);
@@ -1130,7 +1130,7 @@
         }
 
         [Fact]
-        public async void Should_UpdateTrafficInteraction_Async()
+        public async Task Should_UpdateTrafficInteraction_Async()
         {
             var initialTrafficOptions = new TrafficOptions {
                 Flow = TrafficFlow.Absolute
@@ -1148,7 +1148,7 @@
         }
 
         [Fact]
-        public async void Should_UpdateTrafficInteraction_NoTrafficOptionsDefined_Async()
+        public async Task Should_UpdateTrafficInteraction_NoTrafficOptionsDefined_Async()
         {
             var incidents = true;
             var map = new Map("id", _jsRuntimeMock.Object, _loggerMock.Object);
@@ -1710,7 +1710,7 @@
         }
 
         [Fact]
-        public async void Should_CreateImageFromTemplateAsync()
+        public async Task Should_CreateImageFromTemplateAsync()
         {
             var map = new Map("id", _jsRuntimeMock.Object);
             await map.CreateImageFromTemplateAsync("imageId", "templateName", "color", "secondaryColor", 1m);
@@ -1727,7 +1727,7 @@
         }
 
         [Fact]
-        public async void Should_SetCanvasStylePropertyAsync()
+        public async Task Should_SetCanvasStylePropertyAsync()
         {
             var map = new Map("id", _jsRuntimeMock.Object);
             await map.SetCanvasStylePropertyAsync("property", "value");
@@ -1740,7 +1740,7 @@
         [InlineData(null)]
         [InlineData("")]
         [InlineData(" ")]
-        public async void Should_NotSetCanvasStyleProperty_InvalidProperty_Async(string property)
+        public async Task Should_NotSetCanvasStyleProperty_InvalidProperty_Async(string property)
         {
             var map = new Map("id", _jsRuntimeMock.Object);
             await Assert.ThrowsAnyAsync<ArgumentException>(async () => await map.SetCanvasStylePropertyAsync(property, "value"));
@@ -1749,7 +1749,7 @@
         }
 
         [Fact]
-        public async void Should_SetCanvasStylePropertiesAsync()
+        public async Task Should_SetCanvasStylePropertiesAsync()
         {
             var map = new Map("id", _jsRuntimeMock.Object);
             var properties = new Dictionary<string, string> {
@@ -1765,7 +1765,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetCanvasStyleProperties_NullCase_Async()
+        public async Task Should_NotSetCanvasStyleProperties_NullCase_Async()
         {
             var map = new Map("id", _jsRuntimeMock.Object);
 
@@ -1775,7 +1775,7 @@
         }
 
         [Fact]
-        public async void Should_SetOnlyDefinedCanvasProperties_Async()
+        public async Task Should_SetOnlyDefinedCanvasProperties_Async()
         {
             var map = new Map("id", _jsRuntimeMock.Object);
 
@@ -1793,7 +1793,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetCanvasProperties_EmptyCase_Async()
+        public async Task Should_NotSetCanvasProperties_EmptyCase_Async()
         {
             var map = new Map("id", _jsRuntimeMock.Object);
 
@@ -1804,7 +1804,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetCanvasProperties_NoDefinedPropertiesCase_Async()
+        public async Task Should_NotSetCanvasProperties_NoDefinedPropertiesCase_Async()
         {
             var map = new Map("id", _jsRuntimeMock.Object);
 
@@ -1817,7 +1817,7 @@
         }
 
         [Fact]
-        public async void Should_SetCanvasContainerStylePropertyAsync()
+        public async Task Should_SetCanvasContainerStylePropertyAsync()
         {
             var map = new Map("id", _jsRuntimeMock.Object);
             await map.SetCanvasContainerStylePropertyAsync("property", "value");
@@ -1830,7 +1830,7 @@
         [InlineData(null)]
         [InlineData("")]
         [InlineData(" ")]
-        public async void Should_NotSetCanvasContainerStyleProperty_InvalidProperty_Async(string property)
+        public async Task Should_NotSetCanvasContainerStyleProperty_InvalidProperty_Async(string property)
         {
             var map = new Map("id", _jsRuntimeMock.Object);
             await Assert.ThrowsAnyAsync<ArgumentException>(async () => await map.SetCanvasContainerStylePropertyAsync(property, "value"));
@@ -1839,7 +1839,7 @@
         }
 
         [Fact]
-        public async void Should_SetCanvasContainerStylePropertiesAsync()
+        public async Task Should_SetCanvasContainerStylePropertiesAsync()
         {
             var map = new Map("id", _jsRuntimeMock.Object);
             var properties = new Dictionary<string, string> {
@@ -1855,7 +1855,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetCanvasContainerStyleProperties_NullCase_Async()
+        public async Task Should_NotSetCanvasContainerStyleProperties_NullCase_Async()
         {
             var map = new Map("id", _jsRuntimeMock.Object);
 
@@ -1865,7 +1865,7 @@
         }
 
         [Fact]
-        public async void Should_SetOnlyDefinedCanvasContainerProperties_Async()
+        public async Task Should_SetOnlyDefinedCanvasContainerProperties_Async()
         {
             var map = new Map("id", _jsRuntimeMock.Object);
 
@@ -1883,7 +1883,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetCanvasContainerProperties_EmptyCase_Async()
+        public async Task Should_NotSetCanvasContainerProperties_EmptyCase_Async()
         {
             var map = new Map("id", _jsRuntimeMock.Object);
 
@@ -1894,7 +1894,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetCanvasContainerProperties_NoDefinedPropertiesCase_Async()
+        public async Task Should_NotSetCanvasContainerProperties_NoDefinedPropertiesCase_Async()
         {
             var map = new Map("id", _jsRuntimeMock.Object);
 
@@ -1907,7 +1907,7 @@
         }
 
         [Fact]
-        public async void Should_GetCameraOptionsAsync()
+        public async Task Should_GetCameraOptionsAsync()
         {
             var options = new CameraOptions();
             _jsRuntimeMock.Setup(runtime => runtime.InvokeAsync<CameraOptions>(It.IsAny<string>())).ReturnsAsync(options);
@@ -1922,7 +1922,7 @@
         }
 
         [Fact]
-        public async void Should_GetStyleOptionsAsync()
+        public async Task Should_GetStyleOptionsAsync()
         {
             var options = new StyleOptions();
             _jsRuntimeMock.Setup(runtime => runtime.InvokeAsync<StyleOptions>(It.IsAny<string>())).ReturnsAsync(options);
@@ -1937,7 +1937,7 @@
         }
 
         [Fact]
-        public async void Should_GetTrafficOptionsAsync()
+        public async Task Should_GetTrafficOptionsAsync()
         {
             var options = new TrafficOptions();
             _jsRuntimeMock.Setup(runtime => runtime.InvokeAsync<TrafficOptions>(It.IsAny<string>())).ReturnsAsync(options);
@@ -1952,7 +1952,7 @@
         }
 
         [Fact]
-        public async void Should_GetUserInteractionOptionsAsync()
+        public async Task Should_GetUserInteractionOptionsAsync()
         {
             var options = new UserInteractionOptions();
             _jsRuntimeMock.Setup(runtime => runtime.InvokeAsync<UserInteractionOptions>(It.IsAny<string>())).ReturnsAsync(options);

--- a/tests/AzureMapsControl.Components.Tests/Map/MapEventInvokeHelper.cs
+++ b/tests/AzureMapsControl.Components.Tests/Map/MapEventInvokeHelper.cs
@@ -1,5 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Map
 {
+    using System.Threading.Tasks;
+
     using AzureMapsControl.Components.Map;
 
     using Xunit;
@@ -7,7 +9,7 @@
     public class MapEventInvokeHelperTests
     {
         [Fact]
-        public async void Should_InvokeCallback_Async()
+        public async Task Should_InvokeCallback_Async()
         {
             var mapEventArgs = new MapJsEventArgs();
             var assertEqualEventArgs = false;

--- a/tests/AzureMapsControl.Components.Tests/Map/MapService.cs
+++ b/tests/AzureMapsControl.Components.Tests/Map/MapService.cs
@@ -1,5 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Map
 {
+    using System.Threading.Tasks;
+
     using AzureMapsControl.Components.Map;
 
     using Xunit;
@@ -7,7 +9,7 @@
     public class MapServiceTests
     {
         [Fact]
-        public async void Should_AddMap_Async()
+        public async Task Should_AddMap_Async()
         {
             var map = new Map("id");
             var service = new MapService(null);
@@ -16,7 +18,7 @@
         }
 
         [Fact]
-        public async void Should_AddMapAndTriggerOnReady_Async()
+        public async Task Should_AddMapAndTriggerOnReady_Async()
         {
             var map = new Map("id");
             var service = new MapService(null);

--- a/tests/AzureMapsControl.Components.Tests/Markers/HtmlMarker.cs
+++ b/tests/AzureMapsControl.Components.Tests/Markers/HtmlMarker.cs
@@ -1,6 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Markers
 {
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     using AzureMapsControl.Components.Exceptions;
     using AzureMapsControl.Components.Markers;
@@ -235,7 +236,7 @@
         }
 
         [Fact]
-        public async void Should_TogglePopupAsync()
+        public async Task Should_TogglePopupAsync()
         {
             var assertEvent = false;
             var popupInvokeHelper = new PopupInvokeHelper(null);
@@ -264,7 +265,7 @@
         }
 
         [Fact]
-        public async void Should_Not_TogglePopupAsync()
+        public async Task Should_Not_TogglePopupAsync()
         {
             var assertEvent = false;
             var popupInvokeHelper = new PopupInvokeHelper(null);
@@ -281,7 +282,7 @@
         }
 
         [Fact]
-        public async void Should_Not_TogglePopup_NotAddedToMapCase_Async()
+        public async Task Should_Not_TogglePopup_NotAddedToMapCase_Async()
         {
             var popupInvokeHelper = new PopupInvokeHelper(null);
             var marker = new HtmlMarker(new HtmlMarkerOptions {

--- a/tests/AzureMapsControl.Components.Tests/Markers/HtmlMarkerInvokeHelper.cs
+++ b/tests/AzureMapsControl.Components.Tests/Markers/HtmlMarkerInvokeHelper.cs
@@ -1,5 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Markers
 {
+    using System.Threading.Tasks;
+
     using AzureMapsControl.Components.Map;
     using AzureMapsControl.Components.Markers;
 
@@ -7,7 +9,7 @@
     public class HtmlMarkerInvokeHelperTests
     {
         [Fact]
-        public async void Should_InvokeCallback_Async()
+        public async Task Should_InvokeCallback_Async()
         {
             var htmlMarkerEventArgs = new HtmlMarkerJsEventArgs();
             var assertEqualEventArgs = false;

--- a/tests/AzureMapsControl.Components.Tests/Popups/HtmlMarkerPopup.cs
+++ b/tests/AzureMapsControl.Components.Tests/Popups/HtmlMarkerPopup.cs
@@ -1,5 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Popups
 {
+    using System.Threading.Tasks;
+
     using AzureMapsControl.Components.Exceptions;
     using AzureMapsControl.Components.Popups;
     using AzureMapsControl.Components.Runtime;
@@ -41,7 +43,7 @@
         }
 
         [Fact]
-        public async void Should_OpenAsync()
+        public async Task Should_OpenAsync()
         {
             var popup = new HtmlMarkerPopup(new PopupOptions()) {
                 JSRuntime = _jsRuntimeMock.Object,
@@ -54,7 +56,7 @@
         }
 
         [Fact]
-        public async void Should_NotOpen_NotAddedToMapCase_Async()
+        public async Task Should_NotOpen_NotAddedToMapCase_Async()
         {
             var popup = new HtmlMarkerPopup(new PopupOptions()) {
                 HasBeenToggled = true
@@ -66,7 +68,7 @@
         }
 
         [Fact]
-        public async void Should_Not_OpenAsync()
+        public async Task Should_Not_OpenAsync()
         {
             var popup = new HtmlMarkerPopup(new PopupOptions()) {
                 JSRuntime = _jsRuntimeMock.Object
@@ -77,7 +79,7 @@
         }
 
         [Fact]
-        public async void Should_CloseAsync()
+        public async Task Should_CloseAsync()
         {
             var popup = new HtmlMarkerPopup(new PopupOptions()) {
                 JSRuntime = _jsRuntimeMock.Object,
@@ -89,7 +91,7 @@
         }
 
         [Fact]
-        public async void Should_NotClose_NotAddedToMap_Async()
+        public async Task Should_NotClose_NotAddedToMap_Async()
         {
             var popup = new HtmlMarkerPopup(new PopupOptions()) {
                 HasBeenToggled = true
@@ -101,7 +103,7 @@
         }
 
         [Fact]
-        public async void Should_Not_CloseAsync()
+        public async Task Should_Not_CloseAsync()
         {
             var popup = new HtmlMarkerPopup(new PopupOptions()) {
                 JSRuntime = _jsRuntimeMock.Object
@@ -111,7 +113,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveAsync()
+        public async Task Should_RemoveAsync()
         {
             var assertRemoveEvent = false;
             var popup = new HtmlMarkerPopup(new PopupOptions()) {
@@ -128,7 +130,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemove_NotAddedToMapCase_Async()
+        public async Task Should_NotRemove_NotAddedToMapCase_Async()
         {
             var popup = new HtmlMarkerPopup(new PopupOptions()) {
                 HasBeenToggled = true
@@ -139,7 +141,7 @@
         }
 
         [Fact]
-        public async void Should_Not_RemoveAsync()
+        public async Task Should_Not_RemoveAsync()
         {
             var assertRemoveEvent = false;
             var popup = new HtmlMarkerPopup(new PopupOptions()) {
@@ -154,7 +156,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemoveTwice_Async()
+        public async Task Should_NotRemoveTwice_Async()
         {
             var assertRemoveEvent = false;
             var popup = new HtmlMarkerPopup(new PopupOptions()) {
@@ -171,7 +173,7 @@
         }
 
         [Fact]
-        public async void Should_Update_Async()
+        public async Task Should_Update_Async()
         {
             var popup = new HtmlMarkerPopup(new PopupOptions()) {
                 JSRuntime = _jsRuntimeMock.Object,
@@ -189,7 +191,7 @@
         }
 
         [Fact]
-        public async void Should_NotUpdate_NotAddedToMapCase_Async()
+        public async Task Should_NotUpdate_NotAddedToMapCase_Async()
         {
             var popup = new HtmlMarkerPopup(new PopupOptions()) {
                 HasBeenToggled = true
@@ -203,7 +205,7 @@
         }
 
         [Fact]
-        public async void Should_SetOptions_Async()
+        public async Task Should_SetOptions_Async()
         {
             var popup = new HtmlMarkerPopup(new PopupOptions()) {
                 JSRuntime = _jsRuntimeMock.Object,
@@ -221,7 +223,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetOptions_NotAddedToMapCase_Async()
+        public async Task Should_NotSetOptions_NotAddedToMapCase_Async()
         {
             var popup = new HtmlMarkerPopup(new PopupOptions()) {
                 HasBeenToggled = true
@@ -235,7 +237,7 @@
         }
 
         [Fact]
-        public async void Should_Not_Update_Async()
+        public async Task Should_Not_Update_Async()
         {
             var popup = new HtmlMarkerPopup(new PopupOptions()) {
                 JSRuntime = _jsRuntimeMock.Object

--- a/tests/AzureMapsControl.Components.Tests/Popups/Popup.cs
+++ b/tests/AzureMapsControl.Components.Tests/Popups/Popup.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Reflection.PortableExecutable;
+    using System.Threading.Tasks;
 
     using AzureMapsControl.Components.Exceptions;
     using AzureMapsControl.Components.Popups;
@@ -46,7 +47,7 @@
         }
 
         [Fact]
-        public async void Should_OpenAsync()
+        public async Task Should_OpenAsync()
         {
             var popup = new Popup(new PopupOptions()) {
                 JSRuntime = _jsRuntimeMock.Object
@@ -58,7 +59,7 @@
         }
 
         [Fact]
-        public async void Should_NotOpen_NotAddedToMapCase_Async()
+        public async Task Should_NotOpen_NotAddedToMapCase_Async()
         {
             var popup = new Popup(new PopupOptions());
 
@@ -68,7 +69,7 @@
         }
 
         [Fact]
-        public async void Should_NotOpen_RemovedCase_Async()
+        public async Task Should_NotOpen_RemovedCase_Async()
         {
             var popup = new Popup(new PopupOptions()) {
                 JSRuntime = _jsRuntimeMock.Object,
@@ -81,7 +82,7 @@
         }
 
         [Fact]
-        public async void Should_CloseAsync()
+        public async Task Should_CloseAsync()
         {
             var popup = new Popup(new PopupOptions()) {
                 JSRuntime = _jsRuntimeMock.Object
@@ -92,7 +93,7 @@
         }
 
         [Fact]
-        public async void Should_NotClose_NotAddedToMapCase_Async()
+        public async Task Should_NotClose_NotAddedToMapCase_Async()
         {
             var popup = new Popup(new PopupOptions());
             await Assert.ThrowsAnyAsync<ComponentNotAddedToMapException>(async () => await popup.CloseAsync());
@@ -100,7 +101,7 @@
         }
 
         [Fact]
-        public async void Should_NotClose_RemovedCase_Async()
+        public async Task Should_NotClose_RemovedCase_Async()
         {
             var popup = new Popup(new PopupOptions()) {
                 JSRuntime = _jsRuntimeMock.Object,
@@ -111,7 +112,7 @@
         }
 
         [Fact]
-        public async void Should_RemoveAsync()
+        public async Task Should_RemoveAsync()
         {
             var assertRemoveEvent = false;
             var popup = new Popup(new PopupOptions()) {
@@ -127,7 +128,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemove_NotAddedToMapCase_Async()
+        public async Task Should_NotRemove_NotAddedToMapCase_Async()
         {
             var popup = new Popup(new PopupOptions());
             await Assert.ThrowsAnyAsync<ComponentNotAddedToMapException>(async () => await popup.RemoveAsync());
@@ -135,7 +136,7 @@
         }
 
         [Fact]
-        public async void Should_NotRemoveTwice_Async()
+        public async Task Should_NotRemoveTwice_Async()
         {
             var assertRemoveEvent = false;
             var popup = new Popup(new PopupOptions()) {
@@ -151,7 +152,7 @@
         }
 
         [Fact]
-        public async void Should_Update_Async()
+        public async Task Should_Update_Async()
         {
             var popup = new Popup(new PopupOptions()) {
                 JSRuntime = _jsRuntimeMock.Object
@@ -168,7 +169,7 @@
         }
 
         [Fact]
-        public async void Should_NotUpdate_NotAddedToMapCase_Async()
+        public async Task Should_NotUpdate_NotAddedToMapCase_Async()
         {
             var popup = new Popup(new PopupOptions());
             var updatedContent = "updatedContent";
@@ -178,7 +179,7 @@
         }
 
         [Fact]
-        public async void Should_NotUpdate_RemovedCase_Async()
+        public async Task Should_NotUpdate_RemovedCase_Async()
         {
             var popup = new Popup(new PopupOptions()) {
                 JSRuntime = _jsRuntimeMock.Object,
@@ -191,7 +192,7 @@
         }
 
         [Fact]
-        public async void Should_SetOptions_Async()
+        public async Task Should_SetOptions_Async()
         {
             var popup = new Popup(new PopupOptions()) {
                 JSRuntime = _jsRuntimeMock.Object
@@ -208,7 +209,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetOptions_NotAddedToMapCase_Async()
+        public async Task Should_NotSetOptions_NotAddedToMapCase_Async()
         {
             var popup = new Popup(new PopupOptions());
             var updatedContent = "updatedContent";
@@ -218,7 +219,7 @@
         }
 
         [Fact]
-        public async void Should_NotSetOptions_RemovedCase_Async()
+        public async Task Should_NotSetOptions_RemovedCase_Async()
         {
             var popup = new Popup(new PopupOptions()) {
                 JSRuntime = _jsRuntimeMock.Object,
@@ -301,7 +302,7 @@
         }
 
         [Fact]
-        public async void Should_ApplyTemplateAsync()
+        public async Task Should_ApplyTemplateAsync()
         {
             var popup = new Popup() {
                 JSRuntime = _jsRuntimeMock.Object
@@ -324,7 +325,7 @@
         }
 
         [Fact]
-        public async void Should_NotApplyTemplate_NotAddedToMapCaseAsync()
+        public async Task Should_NotApplyTemplate_NotAddedToMapCaseAsync()
         {
             var popup = new Popup();
 
@@ -338,7 +339,7 @@
         }
 
         [Fact]
-        public async void Should_NotApplyTemplate_RemovedCaseAsync()
+        public async Task Should_NotApplyTemplate_RemovedCaseAsync()
         {
             var popup = new Popup() {
                 JSRuntime = _jsRuntimeMock.Object,
@@ -354,7 +355,7 @@
         }
 
         [Fact]
-        public async void Should_NotApplyTemplateWithNullPropertiesAsync()
+        public async Task Should_NotApplyTemplateWithNullPropertiesAsync()
         {
             var popup = new Popup() {
                 JSRuntime = _jsRuntimeMock.Object
@@ -369,7 +370,7 @@
         }
 
         [Fact]
-        public async void Should_ApplyTemplateWithOptionsAsync()
+        public async Task Should_ApplyTemplateWithOptionsAsync()
         {
             var popup = new Popup() {
                 JSRuntime = _jsRuntimeMock.Object
@@ -392,7 +393,7 @@
         }
 
         [Fact]
-        public async void Should_NotApplyTemplateWithOptions_NotAddedToMapCaseAsync()
+        public async Task Should_NotApplyTemplateWithOptions_NotAddedToMapCaseAsync()
         {
             var popup = new Popup();
 
@@ -406,7 +407,7 @@
         }
 
         [Fact]
-        public async void Should_NotApplyTemplateWithOptions_RemovedCaseAsync()
+        public async Task Should_NotApplyTemplateWithOptions_RemovedCaseAsync()
         {
             var popup = new Popup() {
                 JSRuntime = _jsRuntimeMock.Object,
@@ -422,7 +423,7 @@
         }
 
         [Fact]
-        public async void Should_NotApplyTemplateWithOptionsWithNullPropertiesAsync()
+        public async Task Should_NotApplyTemplateWithOptionsWithNullPropertiesAsync()
         {
             var popup = new Popup() {
                 JSRuntime = _jsRuntimeMock.Object

--- a/tests/AzureMapsControl.Components.Tests/Traffic/TrafficOptions.cs
+++ b/tests/AzureMapsControl.Components.Tests/Traffic/TrafficOptions.cs
@@ -1,5 +1,7 @@
 ﻿namespace AzureMapsControl.Components.Tests.Traffic
 {
+    using System.Threading.Tasks;
+
     using AzureMapsControl.Components.Tests.Json;
     using AzureMapsControl.Components.Traffic;
 
@@ -43,7 +45,7 @@
         }
 
         [Fact]
-        public async void Should_WriteTrafficOptions()
+        public async Task Should_WriteTrafficOptions()
         {
             var trafficOptions = new TrafficOptions {
                 Flow = TrafficFlow.Relative
@@ -57,7 +59,7 @@
         }
 
         [Fact]
-        public async void Should_WriteTrafficOptions_WithIncidents()
+        public async Task Should_WriteTrafficOptions_WithIncidents()
         {
             var trafficOptions = new TrafficOptions {
                 Flow = TrafficFlow.Relative,


### PR DESCRIPTION
This PR adds two new methods on the Datasource class : 

- GetClusterExpansionZoom, to retrieve the zoom level at which a cluster will expand or break
- GetClusterLeaves, to retrieve the features contained on a cluster